### PR TITLE
Define Polymer command 'composer:validate:security' used to check security vulnerability in composer packages.

### DIFF
--- a/src/Commands/Validate/ComposerValidateCommand.php
+++ b/src/Commands/Validate/ComposerValidateCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Commands\Validate;
+
+use Robo\Tasks;
+use Robo\Common\ConfigAwareTrait;
+
+/**
+ * Defines commands in the "composer:validate" namespace.
+ */
+class ComposerValidateCommand extends Tasks {
+
+  use ConfigAwareTrait;
+
+  /**
+   * Check security vulnerability in composer packages.
+   *
+   * @param array $options
+   *   An associative array of options:
+   *   - no_dev: Disables auditing of require-dev packages.
+   *   - locked: Audit based on the lock file instead of the installed
+   *   packages.
+   *
+   * @option $no_dev Disables auditing of require-dev packages.
+   * @option $locked Audit based on the lock file instead of the installed
+   *   packages.
+   *
+   * @command composer:validate:security
+   *
+   * @usage composer:validate:security
+   * @usage composer:validate:security --no-dev --locked
+   *
+   * @return int
+   *   The exit code from the task result.
+   *
+   * @throws \Robo\Exception\TaskException
+   */
+  public function security(array $options = ['--no_dev' => FALSE, '--locked' => FALSE]): int {
+    // Show start task message.
+    $this->say("Checking security vulnerability in composer packages...");
+    // Prepare options for the task command.
+    $cmd_options = $this->formatCommandOptions($options);
+    // Define the task.
+    $task = $this->taskExecStack();
+    if ($dir = $this->getConfigValue('repo.root')) {
+      $task->dir($dir);
+    }
+    // Execute the task.
+    $command = $task->exec("composer audit --format=table --ansi $cmd_options");
+    $result = $command->run();
+    // Parse the result.
+    if ($result->wasSuccessful()) {
+      $this->io()->success('Security check successfully passed!');
+      return $result->getExitCode();
+    }
+    else {
+      $this->say($result->getMessage());
+      throw new \RuntimeException('One or more composer packages in your project contains security vulnerability, or you might be utilizing abandoned packages.');
+    }
+   }
+
+  /**
+   * Prepare options for the command..
+   *
+   * @param array $options
+   *   An associative array of options:
+   *   - no_dev: Disables auditing of require-dev packages.
+   *   - locked: Audit based on the lock file instead of the installed
+   *   packages.
+   *
+   * @return string
+   *   The exit code from the task result.
+   */
+  private function formatCommandOptions(array $options): string {
+    $cmd_options = '';
+    if ($options['no_dev']) {
+      $cmd_options .= '--no-dev ';
+    }
+    if ($options['locked']) {
+      $cmd_options .= '--locked ';
+    }
+    return $cmd_options;
+  }
+
+  /**
+   * Gets a config value for a given key.
+   *
+   * @param string $key
+   *   The config key.
+   * @param mixed|null $default
+   *   The default value if the key does not exist in config.
+   *
+   * @return mixed|null
+   *   The config value, or else the default value if they key does not exist.
+   */
+  private function getConfigValue($key, $default = NULL) {
+    if (!$this->getConfig()) {
+      return $default;
+    }
+    return $this->getConfig()->get($key, $default);
+  }
+
+}


### PR DESCRIPTION
### Summary:

This PR solves the task: [PWT-21](https://digitalpolygon.atlassian.net/browse/PWT-21).


This defines a new Polymer command `'composer:validate:security'` used to check security vulnerabilities in composer packages.

The command provides the following two options:
1.  `--no-dev`          Disables auditing for composer require-dev packages.
2.  `--locked `         Audit based on the lock file instead of the installed packages.

### Testing instructions:

You can test/execute the new command by running:

```bash
ddev exec --dir=/var/www/html/test_package ./vendor/bin/polymer composer:validate:security
```

Expected command output:

![image](https://github.com/digitalpolygon/polymer/assets/9256522/5deee220-1a11-4fea-a63f-899d19831d4a)


[PWT-21]: https://digitalpolygon.atlassian.net/browse/PWT-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ