### PR TITLE
Add mechanism for registering core commands and hooks

### DIFF
--- a/bin/polymer-robo-run.php
+++ b/bin/polymer-robo-run.php
@@ -5,7 +5,7 @@
  * Execute Polymer commands via Robo.
  */
 
-use DigitalPolygon\Polymer\Robo\Polymer;
+use DigitalPolygon\Polymer\Polymer;
 use Robo\Common\TimeKeeper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;

--- a/src/Commands/Artifact/BuildCommand.php
+++ b/src/Commands/Artifact/BuildCommand.php
@@ -2,7 +2,6 @@
 
 namespace DigitalPolygon\Polymer\Commands\Artifact;
 
-use Robo\Common\IO;
 use Robo\Tasks;
 
 class BuildCommand extends Tasks {

--- a/src/Commands/Validate/ComposerValidateCommand.php
+++ b/src/Commands/Validate/ComposerValidateCommand.php
@@ -2,8 +2,8 @@
 
 namespace DigitalPolygon\Polymer\Commands\Validate;
 
-use Robo\Tasks;
 use Robo\Common\ConfigAwareTrait;
+use Robo\Tasks;
 
 /**
  * Defines commands in the "composer:validate" namespace.


### PR DESCRIPTION
### Summary:

This PR solves the task: [PWT-27](https://digitalpolygon.atlassian.net/browse/PWT-27).

The PR adds functionality to discover command classes that are shipped with core Polymer.

### Testing instructions:

You can test/execute the new command by running:

```bash
ddev exec --dir=/var/www/html/test_package ./vendor/bin/polymer composer:validate:security
```

Expected command output:

![image](https://github.com/digitalpolygon/polymer/assets/9256522/5deee220-1a11-4fea-a63f-899d19831d4a)


[PWT-21]: https://digitalpolygon.atlassian.net/browse/PWT-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PWT-27]: https://digitalpolygon.atlassian.net/browse/PWT-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ