### PR TITLE
Implement a Config Initializer service and Add a default polymer.yml configuration file.

### DIFF
--- a/bin/polymer-robo-run.php
+++ b/bin/polymer-robo-run.php
@@ -6,10 +6,10 @@
  */
 
 use DigitalPolygon\Polymer\Polymer;
+use DigitalPolygon\Polymer\Config\ConfigInitializer;
 use Robo\Common\TimeKeeper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Robo\Config\Config;
 
 // Start Timer.
 $timer = new TimeKeeper();
@@ -24,7 +24,11 @@ if ($output->isVerbose()) {
     $output->writeln("<comment>Polymer version " . Polymer::getVersion() . "</comment>");
 }
 
-$config = new Config();
+// Initialize configuration.
+$repo_root = find_repo_root();
+$config_initializer = new ConfigInitializer($repo_root, $input);
+$config = $config_initializer->initialize();
+
 // Execute command.
 // phpcs:ignore
 $polymer = new Polymer($config, $input, $output);

--- a/bin/polymer-robo.php
+++ b/bin/polymer-robo.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Bootstrap BLT.
+ * Bootstrap Polymer.
  */
 
 $repo_root = find_repo_root();
@@ -17,9 +17,9 @@ require_once __DIR__ . '/polymer-robo-run.php';
 /**
  * Finds the root directory for the repository.
  *
- * Ordinarily this function is robust, but it can fail if you've symlinked BLT
+ * Ordinarily this function is robust, but it can fail if you've symlinked Polymer
  * into your vendor directory (as with a Composer path repository) and are not
- * running commands from the project root. In this state, BLT has no possible
+ * running commands from the project root. In this state, Polymer has no possible
  * way to identify the root directory.
  *
  * @return bool|string
@@ -63,7 +63,7 @@ function find_repo_root() {
  *   file.
  */
 function find_directory_containing_files($working_directory, array $files, $max_height = 10) {
-    // Find the root directory of the git repository containing BLT.
+    // Find the root directory of the git repository containing Polymer.
     // We traverse the file tree upwards $max_height times until we find $files.
     $file_path = $working_directory;
     for ($i = 0; $i <= $max_height; $i++) {

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,8 @@
+project:
+  human_name: My Polymer site
+  machine_name: my_polymer_site
+  local:
+    hostname: local.${project.machine_name}.com
+    protocol: http
+    uri: ${project.local.protocol}://${project.local.hostname}
+  type: php

--- a/src/Config/ConfigInitializer.php
+++ b/src/Config/ConfigInitializer.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Config;
+
+use Consolidation\Config\Loader\YamlConfigLoader;
+use Consolidation\Config\Loader\ConfigProcessor;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Config Initializer.
+ */
+class ConfigInitializer {
+
+  /**
+   * Config.
+   *
+   * @var \DigitalPolygon\Polymer\Config\PolymerConfig
+   */
+  protected $config;
+
+  /**
+   * Input.
+   *
+   * @var \Symfony\Component\Console\Input\InputInterface
+   */
+  protected $input;
+
+  /**
+   * Loader.
+   *
+   * @var \Consolidation\Config\Loader\YamlConfigLoader
+   */
+  protected $loader;
+
+  /**
+   * Processor.
+   *
+   * @var \Consolidation\Config\Loader\YamlConfigLoader
+   */
+  protected $processor;
+
+  /**
+   * Environment.
+   *
+   * @var string
+   */
+  protected $environment;
+
+  /**
+   * ConfigInitializer constructor.
+   *
+   * @param string $repo_root
+   *   Repo root.
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   *   Input.
+   */
+  public function __construct($repo_root, InputInterface $input) {
+    $this->input = $input;
+    $this->config = new PolymerConfig($repo_root);
+    $this->loader = new YamlConfigLoader();
+    $this->processor = new ConfigProcessor();
+  }
+
+  /**
+   * Initialize.
+   *
+   * @return \DigitalPolygon\Polymer\Config\PolymerConfig
+   *   The Polymer Config.
+   */
+  public function initialize(): PolymerConfig {
+    $environment = $this->determineEnvironment();
+    $this->environment = $environment;
+    $this->config->set('environment', $environment);
+    $this->loadConfigFiles();
+    $this->processConfigFiles();
+    return $this->config;
+  }
+
+  /**
+   * Load config.
+   *
+   * @return $this
+   *   Config.
+   */
+  public function loadConfigFiles(): static {
+    $this->loadDefaultConfig();
+    $this->loadProjectConfig();
+    return $this;
+  }
+
+  /**
+   * Load config.
+   *
+   * @return $this
+   *   Config.
+   */
+  public function loadDefaultConfig(): static {
+    $this->processor->add($this->config->export());
+    $this->processor->extend($this->loader->load($this->config->get('polymer.root') . '/config/default.yml'));
+    return $this;
+  }
+
+  /**
+   * Load config.
+   *
+   * @return $this
+   *   Config.
+   */
+  public function loadProjectConfig(): static {
+    $this->processor->extend($this->loader->load($this->config->get('repo.root') . '/polymer.yml'));
+    $this->processor->extend($this->loader->load($this->config->get('repo.root') . "/{$this->environment}.polymer.yml"));
+    return $this;
+  }
+
+  /**
+   * Process config.
+   *
+   * @return $this
+   *   Config.
+   */
+  public function processConfigFiles(): static {
+    $this->config->replace($this->processor->export());
+    return $this;
+  }
+
+  /**
+   * Determine env.
+   *
+   * @return string|bool
+   *   The Env.
+   */
+  public function determineEnvironment(): mixed {
+    // Support --environment=local.
+    if ($this->input->hasParameterOption('--environment')) {
+      return $this->input->getParameterOption('--environment');
+    }
+    // @todo: get the env from an EnvironmentDetector helper class.
+    return 'local';
+  }
+
+}

--- a/src/Config/PolymerConfig.php
+++ b/src/Config/PolymerConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Config;
+
+use Robo\Config\Config;
+
+/**
+ * Default configuration for Polymer.
+ */
+class PolymerConfig extends Config {
+
+  /**
+   * DefaultConfig constructor.
+   *
+   * @param string $repo_root
+   *   The repository root of the project that depends on Polymer.
+   */
+  public function __construct($repo_root) {
+    parent::__construct();
+    $this->set('repo.root', $repo_root);
+  }
+
+}

--- a/src/Polymer.php
+++ b/src/Polymer.php
@@ -44,7 +44,7 @@ class Polymer implements ContainerAwareInterface {
    * Object constructor.
    *
    * @param \Config\Config $config
-   *   The BLT configuration.
+   *   The Polymer configuration.
    * @param \Symfony\Component\Console\Input\InputInterface $input
    *   The input.
    * @param \Symfony\Component\Console\Output\OutputInterface $output

--- a/test_package/polymer.yml
+++ b/test_package/polymer.yml
@@ -1,0 +1,8 @@
+project:
+  human_name: Tes Polymer Package
+  machine_name: test_polymer_package
+  local:
+    hostname: local.${project.machine_name}.com
+    protocol: http
+    uri: ${project.local.protocol}://${project.local.hostname}
+  type: php


### PR DESCRIPTION
### Summary:

This PR solves the task: [PWT-26](https://digitalpolygon.atlassian.net/browse/PWT-26).

The PR introduces Config Initializer functionality and extends support to read project configurations from a default `polymer.yml` configuration file.

### Testing instructions:

You can test/execute the new command by running:

```bash
ddev exec --dir=/var/www/html/test_package ./vendor/bin/polymer composer:validate:security
```

Expected command output:

![image](https://github.com/digitalpolygon/polymer/assets/9256522/5deee220-1a11-4fea-a63f-899d19831d4a)


[PWT-21]: https://digitalpolygon.atlassian.net/browse/PWT-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PWT-27]: https://digitalpolygon.atlassian.net/browse/PWT-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PWT-26]: https://digitalpolygon.atlassian.net/browse/PWT-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ