### PR TITLE
PWT-63: Add support for adding sites.php entry dynamically during multisite creation.

### DIFF
--- a/settings/sites.php
+++ b/settings/sites.php
@@ -1,0 +1,7 @@
+<?php
+
+$ddev_hostname = getenv('DDEV_HOSTNAME');
+if (!empty($ddev_hostname)) {
+    $sites['{http_port}.' . $ddev_hostname] = '{site_name}';
+    $sites['{https_port}.' . $ddev_hostname] = '{site_name}';
+}

--- a/src/Environment/DDEVEnvironment.php
+++ b/src/Environment/DDEVEnvironment.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Environment;
+
+use Consolidation\Config\Loader\YamlConfigLoader;
+
+/**
+ * Class DDEVEnvironment
+ *
+ * This class provides methods to interact with DDEV environment configurations,
+ * specifically focusing on managing ports and configuration files.
+ */
+final class DDEVEnvironment
+{
+    /**
+     * Config loader for YAML files.
+     *
+     * @var \Consolidation\Config\Loader\YamlConfigLoader
+     */
+    private YamlConfigLoader $loader;
+
+    /**
+     * Array containing DDEV configuration values.
+     *
+     * @var array<string, mixed>
+     */
+    private array $ddevConfig = [];
+
+    /**
+     * Path to the DDEV configuration YAML file.
+     *
+     * @var string
+     */
+    private string $ddevConfigPath;
+
+    /**
+     * Constructor for DDEVEnvironment.
+     *
+     * @param string $repo_root
+     *   The root path of the repository where DDEV configuration resides.
+     */
+    public function __construct(string $repo_root)
+    {
+        $this->ddevConfigPath = "$repo_root/.ddev/config.yaml";
+        $this->loader = new YamlConfigLoader();
+    }
+
+    /**
+     * Checks if the current environment is using DDEV.
+     *
+     * @return bool
+     *   TRUE if the DDEV configuration file exists, FALSE otherwise.
+     */
+    public function isDDEVEnv(): bool
+    {
+        return file_exists($this->ddevConfigPath);
+    }
+
+    /**
+     * Adds a new entry for 'web_extra_exposed_ports' in DDEV configuration.
+     *
+     * @param string $name
+     *   The name of the site or service.
+     * @param int $http_port
+     *   The HTTP port number to expose.
+     * @param int $https_port
+     *   The HTTPS port number to expose.
+     */
+    public function addNewWebExtraExposedPorts(string $name, int $http_port, int $https_port): void
+    {
+        $entries = $this->getConfigValue('web_extra_exposed_ports');
+        $entry = [
+          "name" => $name,
+          "container_port" => $http_port,
+          "http_port" => $http_port,
+          "https_port" => $https_port,
+        ];
+        $entries[] = $entry;
+        // @todo: Persist this change, E.g: $this->setConfigValue('web_extra_exposed_ports', $entries).
+    }
+
+    /**
+     * Determines the next available HTTP and HTTPS ports for multi-site configurations.
+     *
+     * @return array<string, int>
+     *   An array containing the next available HTTP and HTTPS ports.
+     */
+    public function getNextAvailableMultisiteHttpAndHttpsPorts(): array
+    {
+        // Initialize default ports.
+        $http_port = 81;
+        $https_port = 444;
+        // Retrieve existing port configurations.
+        $items = $this->getConfigValue('web_extra_exposed_ports');
+        // Determine maximum ports in use.
+        if ($items != null) {
+            foreach ($items as $item) {
+                $item_http_port = $item['http_port'] ?? 0;
+                $item_https_port = $item['https_port'] ?? 0;
+                $http_port = max($http_port, $item_http_port);
+                $https_port = max($https_port, $item_https_port);
+            }
+        }
+        // Increment ports by one for the next available ports.
+        $http_port++;
+        $https_port++;
+        // Return array containing the next available HTTP and HTTPS ports.
+        return [
+          'http_port' => $http_port,
+          'https_port' => $https_port,
+        ];
+    }
+
+    /**
+     * Retrieves a specific configuration value from DDEV configuration.
+     *
+     * @param string $key
+     *   The key of the configuration value to retrieve.
+     *
+     * @return array<string, int>|null
+     *   The configuration value corresponding to the key, or NULL if not found.
+     */
+    private function getConfigValue(string $key): ?array
+    {
+        if (empty($this->ddevConfig)) {
+            $this->loadDDEVConfig();
+        }
+        // @phpstan-ignore-next-line
+        return $this->ddevConfig[$key] ?? null;
+    }
+
+    /**
+     * Loads the DDEV configuration from the YAML file into memory.
+     */
+    private function loadDDEVConfig(): void
+    {
+        $this->loader->load($this->ddevConfigPath);
+        $this->ddevConfig = $this->loader->export();
+    }
+}

--- a/src/Robo/Commands/Copy/DrupalMultisiteCommand.php
+++ b/src/Robo/Commands/Copy/DrupalMultisiteCommand.php
@@ -4,34 +4,165 @@ namespace DigitalPolygon\Polymer\Robo\Commands\Copy;
 
 use Consolidation\AnnotatedCommand\Attributes\Argument;
 use Consolidation\AnnotatedCommand\Attributes\Command;
+use DigitalPolygon\Polymer\Environment\DDEVEnvironment;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 use Robo\Contract\VerbosityThresholdInterface;
-use Robo\Symfony\ConsoleIO;
+use Robo\Exception\AbortTasksException;
 
+/**
+ * Defines commands related to Drupal multi-site operations and configurations.
+ *
+ * This command facilitates the creation and configuration of Drupal multi-sites,
+ * leveraging local development environments like DDEV for streamlined setup.
+ */
 class DrupalMultisiteCommand extends TaskBase
 {
     /**
-     * Copy Drupal multi-site configuration.
+     * Path to the 'default' site directory.
+     *
+     * @var string
+     */
+    private string $defaultSiteDir;
+
+    /**
+     * Path to the current site directory being created/configured.
+     *
+     * @var string
+     */
+    private string $currentSiteDir;
+
+    /**
+     * Path to the template sites.php file used for multi-site configurations.
+     *
+     * @var string
+     */
+    private string $sitesFileTemplate;
+
+    /**
+     * Path to the sites.php file where new site configurations are saved.
+     *
+     * @var string
+     */
+    private string $sitesFile;
+
+    /**
+     * Instance of DDEVEnvironment for managing DDEV-specific operations.
+     *
+     * @var \DigitalPolygon\Polymer\Environment\DDEVEnvironment
+     */
+    private DDEVEnvironment $ddevEnv;
+
+    /**
+     * Initializes paths for site directories based on the site name.
+     *
+     * @param string $site_name
+     *   The name of the site being created/configured.
+     *
+     * @throws \Robo\Exception\AbortTasksException
+     *   If initialization fails or the site directory already exists.
+     */
+    private function initialize(string $site_name): void
+    {
+        /** @var string $docroot */
+        $docroot = $this->getConfigValue('docroot');
+        $this->defaultSiteDir = "$docroot/sites/default";
+        $this->currentSiteDir = "$docroot/sites/$site_name";
+        // Check if DDEV is configured for local development.
+        /** @var string $repo_root */
+        $repo_root = $this->getConfigValue('repo.root');
+        $this->ddevEnv = new DDEVEnvironment($repo_root);
+        /** @var string $polymer_root */
+        // Path to the template and target 'sites.php' files.
+        $polymer_root = $this->getConfigValue('polymer.root');
+        $this->sitesFileTemplate =  "$polymer_root/settings/sites.php";
+        $this->sitesFile = "$docroot/sites/sites.php";
+        // Ensure the new site directory does not already exist.
+        if (file_exists($this->currentSiteDir)) {
+            throw new AbortTasksException("Cannot create new multisite. The directory '{$this->currentSiteDir}' already exists.");
+        }
+    }
+
+    /**
+     * Copies Drupal multi-site configuration from default site to a new site.
      *
      * @return int
-     *   The exit code from the task result.
+     *   The exit code from the task result (0 for success, 1 for failure).
      *
-     * @throws \Robo\Exception\TaskException
+     * @throws \Robo\Exception\AbortTasksException
+     *   If the directory copy operation fails or adding site configuration
+     *   to 'sites.php' fails.
      */
     #[Command(name: 'drupal:multisite:create')]
     #[Argument(name: 'site_name', description: 'The name of the new site. This will also be used as the directory name.')]
-    public function copyDrupalMultiSite(ConsoleIO $io, string $site_name): int
+    public function copyDrupalMultiSite(string $site_name): int
     {
-        $docroot = $this->getConfigValue('docroot');
-        $default_site_dir = $docroot . '/sites/default';
-        $new_site_dir = $docroot . '/sites/' . $site_name;
-        // Copy the default directory contents, minus files and local settings, and then replace values that need
-        // to be different.
-        // @phpstan-ignore method.notFound
-        $result = $this->taskCopyDir([$default_site_dir => $new_site_dir])
-            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-            ->exclude(['local.settings.php', 'files'])
-            ->run();
+        // Initialize paths and environment settings for the new site.
+        $this->initialize($site_name);
+        // Perform directory copy operation from 'default' to new site directory.
+        $this->performCopyOperation();
+        // Add the new site to the list of multi-site directory aliases if using DDEV.
+        $confirmation_message = "Would you like to generate a new 'web_extra_exposed_ports' entry for this site inside DDEV config?";
+        if ($this->ddevEnv->isDDEVEnv() && $this->confirm($confirmation_message, true)) {
+            $this->addSiteToMultisiteDirectoryAliases($site_name);
+        }
+        // Return a success exit code.
         return 0;
+    }
+
+    /**
+     * Performs the directory copy operation for the new Drupal site.
+     *
+     * @throws \Robo\Exception\AbortTasksException
+     *   If the directory copy operation fails.
+     */
+    private function performCopyOperation(): void
+    {
+        // Copy the default directory contents, excluding files and local settings.
+        /** @var \Robo\Task\Filesystem\CopyDir $task */
+        $task = $this->taskCopyDir([$this->defaultSiteDir => $this->currentSiteDir]);
+        $task->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE);
+        $task->exclude(['local.settings.php', 'files']);
+        $result = $task->run();
+        if (!$result->wasSuccessful()) {
+            throw new AbortTasksException("Failed to copy sites directory from '{$this->defaultSiteDir}' to '{$this->currentSiteDir}'.", $result->getExitCode());
+        }
+    }
+
+    /**
+     * Adds the new site to the list of multi-site directory aliases in DDEV configuration.
+     *
+     * @param string $site_name
+     *   The name of the new site.
+     *
+     * @throws \Robo\Exception\AbortTasksException
+     *   If adding the site configuration to 'sites.php' or updating DDEV configuration fails.
+     */
+    private function addSiteToMultisiteDirectoryAliases(string $site_name): void
+    {
+        // Determine available HTTP and HTTPS ports for the new site.
+        $ports = $this->ddevEnv->getNextAvailableMultisiteHttpAndHttpsPorts();
+        $http_port = $ports['http_port'];
+        $https_port = $ports['https_port'];
+        // Add new entry for 'web_extra_exposed_ports' in DDEV configuration.
+        $this->ddevEnv->addNewWebExtraExposedPorts($site_name, $http_port, $https_port);
+        // Injects this information into site 'sites.php' file.
+        /** @var string $sites_content */
+        $sites_content = file_get_contents($this->sitesFileTemplate);
+        /** @var \Robo\Task\File\Write $task */
+        $task = $this->taskWriteToFile($this->sitesFile);
+        $task->text($sites_content);
+        // Replace site name and ports from the template file.
+        $task->place('site_name', $site_name);
+        $task->place('http_port', (string) $http_port);
+        $task->place('https_port', (string) $https_port);
+        $task->append(true);
+        $task->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE);
+        $result = $task->run();
+        if (!$result->wasSuccessful()) {
+            throw new AbortTasksException("Unable to add new site alias into the 'sites.php' file.", $result->getExitCode());
+        }
+        // Inform the user about DDEV configuration changes and the new site's URL.
+        $new_site_url =  "https://{$site_name}.ddev.site:{$https_port}";
+        $this->say("New site has been successfully configured. Restart DDEV using the command 'ddev restart' to reflect the changes. The new site will be accessible at this URL: {$new_site_url}");
     }
 }


### PR DESCRIPTION
### Summary:

1. This PR solves the task: [PWT-63](https://digitalpolygon.atlassian.net/browse/PWT-63).

#### Changes Made

- Add support for adding sites.php entry dynamically during multisite creation

### Testing instructions:

You can test/execute the new command by running:

```bash
ddev exec --dir=/var/www/html/test_drupal10 polymer drupal:multisite:create sitename;
```
![Screenshot from 2024-07-05 17-02-51](https://github.com/digitalpolygon/polymer/assets/9256522/9e5989f0-a4bf-488b-b8ac-4da091f54676)


[PWT-63]: https://digitalpolygon.atlassian.net/browse/PWT-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced multi-site setup for Drupal using DDEV environments.
  - Automated site configurations based on environment's hostname and ports.
  - Added functionality to manage and configure multi-site directories efficiently.

- **Improvements**
  - Streamlined the process for creating and configuring Drupal multi-sites.
  - Improved integration with DDEV for managing environment-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->