### PR TITLE
PWT-89: Synchronize remote files (Drupal).

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -56,3 +56,20 @@ cm:
     # Install site directly from existing config.
     # This cannot be used if your install profile implements hook_install.
     install_from_config: false
+
+sync:
+  # By default, files are not synced during sync:refresh.
+  # Set this value to 'true' or pass -D sync.public-files=true
+  # to override this behavior.
+  public-files: false
+  private-files: false
+  # Paths to exclude during file syncing operations.
+  exclude-paths:
+    - styles
+    - css
+    - js
+  commands:
+  # @todo update the commands.
+    - source:build:composer
+    - polymer:init:settings
+    - drupal:update

--- a/src/Robo/Commands/Drupal/SyncCommand.php
+++ b/src/Robo/Commands/Drupal/SyncCommand.php
@@ -7,6 +7,8 @@ use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 use Consolidation\AnnotatedCommand\Attributes\Command;
 use DigitalPolygon\Polymer\Robo\Exceptions\PolymerException;
 use Robo\Result;
+use Symfony\Component\Yaml\Yaml;
+use DigitalPolygon\Polymer\Robo\Tasks\DrushTask;
 
 class SyncCommand extends TaskBase
 {
@@ -14,7 +16,6 @@ class SyncCommand extends TaskBase
      * Copies remote db to local db for default site.
      *
      * @throws \Robo\Exception\AbortTasksException|TaskException
-     *   When unable to create or require settings files.
      */
     #[Command(name: 'drupal:site:sync', aliases: ['dss', 'drupal:ss'])]
     public function siteSync(): Result
@@ -39,9 +40,66 @@ class SyncCommand extends TaskBase
         try {
             $result = $task->run();
         } catch (TaskException $e) {
-            $this->say('Sync failed. Often this is due to Drush version mismatches: https://digitalpolygon.github.io/polymer/commands/artifact_compile');
+            $this->say('Sync failed. Often this is due to Drush version mismatches: https://digitalpolygon.github.io/polymer');
             throw new PolymerException($e->getMessage());
         }
+
+        return $result;
+    }
+
+    /**
+     * Copies public remote files to local machine.
+     *
+     * @throws \Robo\Exception\AbortTasksException|TaskException
+     */
+    #[Command(name: 'drupal:site:sync:files', aliases: ['dsf', 'drupal:sf'])]
+    public function syncPublicFiles(): Result
+    {
+        $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
+
+        /** @var string $site_dir */
+        $site_dir = $this->getConfigValue('site');
+
+        $task = $this->taskDrush()
+        ->alias('')
+        ->uri('')
+        ->drush('rsync')
+        ->arg($remote_alias . ':%files/')
+        ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files");
+
+        /** @var array<string> $exclude_paths */
+        $exclude_paths = $this->getConfigValue('sync.exclude-paths');
+        $task->option('exclude-paths', implode(':', $exclude_paths));
+        $result = $task->run();
+
+        return $result;
+    }
+
+    /**
+     * Copies private remote files to local machine.
+     *
+     * @throws \Robo\Exception\AbortTasksException|TaskException
+     */
+    #[Command(name: 'drupal:site:sync:private-files', aliases: ['dspf', 'drupal:spf'])]
+    public function syncPrivateFiles(): Result
+    {
+        $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
+
+        /** @var string $site_dir */
+        $site_dir = $this->getConfigValue('site');
+        $private_files_local_path = $this->getConfigValue('repo.root') . "/files-private/$site_dir";
+
+        $task = $this->taskDrush()
+        ->alias('')
+        ->uri('')
+        ->drush('rsync')
+        ->arg($remote_alias . ':%private/')
+        ->arg($private_files_local_path);
+
+        /** @var array<string> $exclude_paths */
+        $exclude_paths = $this->getConfigValue('sync.exclude-paths');
+        $task->option('exclude-paths', implode(':', $exclude_paths));
+        $result = $task->run();
 
         return $result;
     }

--- a/test_drupal10/polymer.yml
+++ b/test_drupal10/polymer.yml
@@ -50,3 +50,20 @@ drush:
   dir: ${docroot}
   sanitize: true
   alias: ${drush.default_alias}
+
+sync:
+  # By default, files are not synced during sync:refresh.
+  # Set this value to 'true' or pass -D sync.public-files=true
+  # to override this behavior.
+  public-files: false
+  private-files: false
+  # Paths to exclude during file syncing operations.
+  exclude-paths:
+    - styles
+    - css
+    - js
+  commands:
+  # @todo update the commands.
+    - source:build:composer
+    - polymer:init:settings
+    - drupal:update


### PR DESCRIPTION
## Things covered:

Closed [PWT-89](https://digitalpolygon.atlassian.net/browse/PWT-89)

### Changes:
Created 2 new commands to copy files
1. `drupal:site:sync:files`
2. `drupal:site:sync:private-files`

Updated config files to include the drupal update related configs.

### Testing steps:

To see the new commands
```bash
ddev exec --dir=/var/www/html/test_drupal10 polymer
```

[PWT-89]: https://digitalpolygon.atlassian.net/browse/PWT-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ