### PR TITLE
PWT-18: Add a command for installing site (Drupal).

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -7,6 +7,8 @@ project:
     uri: ${project.local.protocol}://${project.local.hostname}
   type: php
   recipe: common
+  profile:
+    name: minimal
 
 deploy:
   build-dependencies: true
@@ -76,3 +78,30 @@ sync:
     # That's why files needs to be synchronized locally first.
     # Command order can be changed as per the need in custom polymer.config file.
     - drupal:update
+
+# Settings for installing Drupal.
+drupal:
+  account:
+    # Admin account name and password will be randomly generated unless set here.
+    #name: admin
+    #pass:
+    mail: no-reply@example.com
+  site.mail: ${drupal.account.mail}
+  locale: en
+  local_settings_file: ${docroot}/sites/${site}/settings/local.settings.php
+  settings_file: ${docroot}/sites/${site}/settings.php
+  db:
+    database: drupal
+    username: drupal
+    password: drupal
+    host: localhost
+    port: 3306
+
+setup:
+  # Valid values are install, sync, import.
+  strategy: install
+  # If setup.strategy is import, this file will be imported. File path is
+  # relative to drupal docroot directory.
+  dump-file: null
+  # Arguments to pass to drush si.
+  install-args: 'install_configure_form.enable_update_status_module=NULL'

--- a/src/Robo/Commands/Drupal/InstallCommand.php
+++ b/src/Robo/Commands/Drupal/InstallCommand.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Commands\Drupal;
+
+use Robo\Result;
+use Robo\Common\IO;
+use Robo\Exception\TaskException;
+use Symfony\Component\Finder\Finder;
+use League\Container\Definition\Definition;
+use Robo\Contract\VerbosityThresholdInterface;
+use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
+use DigitalPolygon\Polymer\Robo\Tasks\DrushTask;
+use Symfony\Component\Console\Input\InputOption;
+use Consolidation\AnnotatedCommand\Attributes\Usage;
+use DigitalPolygon\Polymer\Robo\Common\RandomString;
+use Consolidation\AnnotatedCommand\Attributes\Option;
+use DigitalPolygon\Polymer\Robo\Config\DefaultConfig;
+use DigitalPolygon\Polymer\Robo\Config\PolymerConfig;
+use Consolidation\AnnotatedCommand\Attributes\Command;
+use DigitalPolygon\Polymer\Robo\Exceptions\PolymerException;
+use DigitalPolygon\Polymer\Robo\Tasks\Command as PolymerCommand;
+
+/**
+ * Defines commands in the "drupal:*" namespace.
+ */
+class InstallCommand extends TaskBase
+{
+    use IO;
+
+    /**
+     * The site name.
+     * @var string
+     */
+    protected string $site = '';
+
+    /**
+     * Installs Drupal and sets correct file/directory permissions.
+     *
+     * @param array<string, int|false> $options
+     *   The artifact deploy command options.
+     *
+     * @throws \Robo\Exception\AbortTasksException|TaskException
+     */
+    #[Command(name: 'drupal:site:install', aliases: ['dsi'])]
+    #[Usage(name: 'polymer drupal:site:install', description: 'Installs Drupal site.')]
+    #[Usage(name: 'polymer drupal:site:install --site={site_name}', description: 'Add site name.')]
+    #[Option(name: 'site', description: 'The site name.')]
+    public function drupalSiteInstall(array $options = ['site' => InputOption::VALUE_OPTIONAL]): void
+    {
+        /** @var string $site */
+        $site = $options['site'] ?? 'default';
+        $this->site = $site;
+
+        /** @var PolymerCommand[] $commands */
+        $commands = [];
+        $commands[] = new PolymerCommand('internal:drupal:install');
+        $strategy = $this->getConfigValue('cm.strategy');
+
+        if (in_array($strategy, ['core-only', 'config-split'])) {
+            $commands[] = new PolymerCommand('drupal:config:import');
+        }
+        $this->invokeCommands($commands);
+        $this->setSitePermissions();
+    }
+
+    /**
+     * Set correct permissions.
+     *
+     * For directories (755) and files (644) in docroot/sites/[site] (excluding
+     * docroot/sites/[site]/files).
+     *
+     * @throws \Robo\Exception\AbortTasksException|TaskException
+     */
+    protected function setSitePermissions(): void
+    {
+        /** @var \Robo\Task\Filesystem\FilesystemStack $taskFilesystemStack */
+        $taskFilesystemStack = $this->taskFilesystemStack();
+        $multisite_dir = $this->getConfigValue('docroot') . '/sites/' . $this->site;
+
+        /** @var Finder $finder */
+        $finder = new Finder();
+        $dirs = $finder
+        ->in($multisite_dir)
+        ->directories()
+        ->depth('< 1')
+        ->exclude('files');
+        foreach ($dirs->getIterator() as $dir) {
+            $taskFilesystemStack->chmod($dir->getRealPath(), 0755);
+        }
+        $files = $finder
+        ->in($multisite_dir)
+        ->files()
+        ->depth('< 1')
+        ->exclude('files');
+        foreach ($files->getIterator() as $file) {
+            $taskFilesystemStack->chmod($file->getRealPath(), 0644);
+        }
+
+        $taskFilesystemStack->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE);
+        $result = $taskFilesystemStack->run();
+
+        if (!$result->wasSuccessful()) {
+            $this->logger->warning('Unable to set permissions for site directories and files.');
+        }
+    }
+
+  /**
+   * Installs Drupal and imports configuration.
+   *
+   * @return \Robo\Result
+   *   The `drush site-install` command result.
+   *
+   * @throws \Robo\Exception\AbortTasksException|TaskException
+   */
+    #[Command(name: 'internal:drupal:install')]
+    public function install(): Result
+    {
+        // Allows for installs to define custom user 0 name.
+        if ($this->getConfigValue('drupal.account.name') !== null) {
+            /** @var string $username */
+            $username = $this->getConfigValue('drupal.account.name');
+        } else {
+            // Generate a random, valid username.
+            // @see \Drupal\user\Plugin\Validation\Constraint\UserNameConstraintValidator
+            /** @var string $username */
+            $username = RandomString::string(
+                10,
+                false,
+                function ($string) {
+                    return !preg_match('/[^\x{80}-\x{F7} a-z0-9@+_.\'-]/i', $string);
+                },
+                'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#%^&*()_?/.,+=><'
+            );
+        }
+
+        /** @var string $project_profile_name */
+        $project_profile_name = $this->getConfigValue('project.profile.name');
+
+        /** @var string $setup_install */
+        $setup_install = $this->getConfigValue('setup.install-args');
+
+        /** @var string $project_human_name */
+        $project_human_name = $this->getConfigValue('project.human_name');
+
+        /** @var string $drupal_site_mail */
+        $drupal_site_mail = $this->getConfigValue('drupal.site.mail');
+
+        /** @var string $drupal_account_mail */
+        $drupal_account_mail = $this->getConfigValue('drupal.account.mail');
+
+        /** @var string $drupal_locale */
+        $drupal_locale = $this->getConfigValue('drupal.locale');
+
+        /** @var DrushTask $task */
+        $task = $this->taskDrush()
+        ->drush("site-install")
+        ->arg($project_profile_name)
+        ->rawArg($setup_install)
+        ->option('sites-subdir', $this->site)
+        ->option('site-name', $project_human_name)
+        ->option('site-mail', $drupal_site_mail)
+        ->option('account-name', $username)
+        ->option('account-mail', $drupal_account_mail)
+        ->option('locale', $drupal_locale)
+        ->verbose(true)
+        ->printOutput(true);
+
+        // Allow installs to define a custom user 1 password.
+        if ($this->getConfigValue('drupal.account.pass') !== null) {
+            /** @var string $drupal_account_pass */
+            $drupal_account_pass = $this->getConfigValue('drupal.account.pass');
+            $task->option('account-pass', $drupal_account_pass);
+        }
+
+        // Install site from existing config if supported.
+        $strategy = $this->getConfigValue('cm.strategy');
+        $install_from_config = $this->getConfigValue('cm.core.install_from_config');
+        $strategy_uses_config = in_array($strategy, ['core-only', 'config-split']);
+        if ($install_from_config && $strategy_uses_config) {
+            $core_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("cm.core.dirs.sync.path") . '/core.extension.yml';
+            if (file_exists($core_config_file)) {
+                $task->option('existing-config');
+            }
+        }
+
+        $result = $task->interactive($this->input()->isInteractive())->run();
+        if (!$result->wasSuccessful()) {
+            throw new PolymerException("Failed to install Drupal!");
+        }
+
+        return $result;
+    }
+}

--- a/src/Robo/Common/RandomString.php
+++ b/src/Robo/Common/RandomString.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Common;
+
+/**
+ * Utility class for generating random strings.
+ */
+class RandomString
+{
+  /**
+   * The maximum number of times name() and string() can loop.
+   *
+   * This prevents infinite loops if the length of the random value is very
+   * small.
+   *
+   * @see \Drupal\Tests\Component\Utility\RandomTest
+   */
+    const MAXIMUM_TRIES = 100;
+
+  /**
+   * Generates a random string of ASCII characters of codes 32 to 126.
+   *
+   * The generated string includes alpha-numeric characters and common
+   * miscellaneous characters. Use this method when testing general input
+   * where the content is not restricted.
+   *
+   * @param int $length
+   *   Length of random string to generate.
+   * @param bool $unique
+   *   (optional) If TRUE ensures that the random string returned is unique.
+   *   Defaults to FALSE.
+   * @param callable $validator
+   *   (optional) A callable to validate the string. Defaults to NULL.
+   * @param string $characters
+   *   (optional) A string containing all possible characters that may be used
+   *   to generate the random string.
+   *
+   * @return string
+   *   Randomly generated string.
+   *
+   * @see \Drupal\Component\Utility\Random::name()
+   */
+    public static function string($length = 8, $unique = false, callable $validator = null, $characters = '')
+    {
+        $counter = 0;
+        /** @var array<string> $strings */
+        $strings = [];
+        $characters_array = $characters ? str_split($characters) : [];
+
+      // Continue to loop if $unique is TRUE and the generated string is not
+      // unique or if $validator is a callable that returns FALSE. To generate a
+      // random string this loop must be carried out at least once.
+        do {
+            if ($counter == static::MAXIMUM_TRIES) {
+                throw new \RuntimeException('Unable to generate a unique random name');
+            }
+            $str = '';
+            for ($i = 0; $i < $length; $i++) {
+                if ($characters_array) {
+                    $position = mt_rand(0, count($characters_array) - 1);
+                    $str .= $characters_array[$position];
+                } else {
+                    $str .= chr(mt_rand(32, 126));
+                }
+            }
+            $counter++;
+
+            $continue = false;
+            if ($unique) {
+                $continue = isset($strings[$str]);
+            }
+            if (!$continue && is_callable($validator)) {
+              // If the validator callback returns FALSE generate another random
+              // string.
+                $continue = !call_user_func($validator, $str);
+            }
+        } while ($continue);
+
+        if ($unique) {
+            $strings[$str] = true;
+        }
+
+        return $str;
+    }
+}


### PR DESCRIPTION
Closes [PWT-18](https://digitalpolygon.atlassian.net/browse/PWT-18)
### Things covered
1. Added `drupal:site:install` command to install the drupal site.
2. Uses
```
➜  polymer-drupal-pantheon-testing git:(main) ✗ ddev polymer drupal:site:install --help
Description:
  Installs Drupal and sets correct file/directory permissions.

Usage:
  drupal:site:install [options]
  dsi
  drupal:site:install polymer drupal:site:install
  drupal:site:install polymer drupal:site:install --site={site_name}

Options:
      --site[=SITE]     The site name.
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
  ```

[PWT-18]: https://digitalpolygon.atlassian.net/browse/PWT-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ