### PR TITLE
Remove build target if no dependent builds specified in artifact.

### DIFF
--- a/src/Robo/Commands/Artifact/CompileCommand.php
+++ b/src/Robo/Commands/Artifact/CompileCommand.php
@@ -128,8 +128,7 @@ class CompileCommand extends TaskBase
                     unset($commands[$key]);
                 }
             }
-        }
-        else {
+        } else {
             // Replace the 'build' command from the build-recipe for the dependent builds specified in the artifact.
             foreach ($commands as $key => $command) {
                 if (str_starts_with($command->getName(), 'build')) {

--- a/src/Robo/Tasks/TaskBase.php
+++ b/src/Robo/Tasks/TaskBase.php
@@ -89,7 +89,7 @@ abstract class TaskBase extends Tasks implements ConfigAwareInterface, LoggerAwa
         // obviates the need to check the exit code of every invoked command.
         if ($exit_code) {
             $this->output->writeln("The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.");
-            throw new TaskException($this, "Command `$command_string}` exited with code $exit_code.");
+            throw new TaskException($this, "Command `$command_string` exited with code $exit_code.");
         }
     }
 


### PR DESCRIPTION
# Changes

- Removes build command from artifact compile pipeline if no build dependencies are actually specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for build commands based on artifact configurations.
	- Improved control flow for handling dependent builds in command processing.

- **Bug Fixes**
	- Corrected a typo in error message formatting to ensure clearer and accurate command representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->