### PR TITLE
PWT-98: Merge remote artifact branch changes locally prior to pushing

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,9 @@ parameters:
         - 'test_package'
         - 'test_drupal10'
         - 'src/Robo/Common/ArrayManipulator.php'
+    ignoreErrors:
+        -
+            message: "#^Call to an undefined method Robo\\\\Collection\\\\CollectionBuilder#"
 #services:
 #    -
 #        class: DigitalPolygon\PolymerTest\PHPStan\CollectionBuilderReflectionExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
     excludePaths:
         - 'test_package'
         - 'test_drupal10'
+        - 'src/Robo/Common/ArrayManipulator.php'
 #services:
 #    -
 #        class: DigitalPolygon\PolymerTest\PHPStan\CollectionBuilderReflectionExtension

--- a/src/Robo/Commands/Artifact/CompileCommand.php
+++ b/src/Robo/Commands/Artifact/CompileCommand.php
@@ -8,6 +8,7 @@ use DigitalPolygon\Polymer\Robo\Recipes\RecipeInterface;
 use DigitalPolygon\Polymer\Robo\Tasks\Command as PolymerCommand;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 use Robo\Exception\TaskException;
+use Robo\Symfony\ConsoleIO;
 
 /**
  * Defines commands in the "artifact:compile" namespace.
@@ -45,137 +46,47 @@ class CompileCommand extends TaskBase
      */
     #[Command(name: 'artifact:compile')]
     #[Usage(name: 'polymer artifact:compile -v', description: 'Builds deployment artifact.')]
-    public function buildArtifact(string $artifact): void
+    public function buildArtifact(ConsoleIO $io, string $artifact): void
     {
-        // Gather build source and target information.
-        $this->initialize();
-        // Show start task message.
-        $recipe_name = $this->getBuildRecipeName($artifact);
-        $this->say("Generating build artifact '{$artifact}' using build recipe: '$recipe_name'...");
-        // Load the build recipe for the requested artifact.
-        $this->loadRecipes($artifact);
-        // Collect eh build commands to execute based on the env context and recipe used.
-        $commands = $this->collectBuildCommands($artifact);
-        // Execute the build process.
-        $this->invokeHook("pre-deploy-build");
-        $this->invokeCommands($commands);
-        $this->invokeHook("post-deploy-build");
-        $this->say("<info>The deployment artifact was generated at {$this->deployDir}.</info>");
-    }
-
-    /**
-     * Describe the tasks associated with the build artifact command.
-     *
-     * @command artifact:compile:describe
-     *
-     * @usage artifact:compile:describe
-     */
-    #[Command(name: 'artifact:compile:describe')]
-    #[Usage(name: 'polymer artifact:compile:describe', description: 'Describe the tasks associated with the build artifact command.')]
-    public function buildArtifactDescribe(string $artifact): void
-    {
-        // Gather build source and target information.
-        $this->initialize();
-        // Load the build recipe for the requested artifact.
-        $this->loadRecipes($artifact);
-        // Show operation to execute.
-        $recipe_name = $this->getBuildRecipeName($artifact);
-        $this->say("The 'artifact:compile' command for '{$artifact}' using build recipe: '$recipe_name' executes the following list of commands in the specified order:");
-
-        // Collect eh build commands to execute based on the env context and recipe used.
-        $commands = $this->collectBuildCommands($artifact);
-        $this->listCommands($commands);
-    }
-
-    /**
-     * Gather build source and target information.
-     *
-     * @throws \Robo\Exception\TaskException
-     */
-    protected function initialize(): void
-    {
-        // @phpstan-ignore-next-line
-        $this->deployDir = $this->getConfigValue('deploy.dir');
-        // @phpstan-ignore-next-line
-        $this->deployDocroot = $this->getConfigValue('deploy.docroot');
-        if (!$this->deployDir || !$this->deployDocroot) {
+        /** @var string $deployDir */
+        $deployDir = $this->getConfigValue('deploy.dir');
+        /** @var string $deployDocroot */
+        $deployDocroot = $this->getConfigValue('deploy.docroot');
+        if (!$deployDir || !$deployDocroot) {
             throw new TaskException($this, 'Configuration deploy.dir and deploy.docroot must be set to run this command');
         }
-    }
 
-    /**
-     * Collects the filtered list of commands for the artifact build process.
-     *
-     * @param string $artifact
-     *   The artifact definition to use for the build.
-     *
-     * @return PolymerCommand[]
-     *   The filtered list of commands to be executed during the artifact build.
-     */
-    private function collectBuildCommands(string $artifact): array
-    {
-        $artifact_config = $this->getConfigValue('artifacts.' . $artifact);
-        if (empty($artifact_config)) {
-            throw new \Exception("Artifact '{$artifact}' not found in the configuration.");
-        }
-        $commands = $this->buildRecipe->getCommands();
-        // Check if the artifact contains dependent-builds and add them.
+        $application = $this->getContainer()->get('application');
+        // Show start task message.
+        $io->say("Generating build artifact '{$artifact}'...");
+
+        // Execute the build process.
+        $this->invokeHook("pre-deploy-build");
+
+        /** @var array<int,string> $dependent_builds */
         $dependent_builds = $this->getDependentBuilds($artifact);
-        if (empty($dependent_builds)) {
-            // Remove any build commands if there were no build dependencies specified.
-            foreach ($commands as $key => $command) {
-                if (str_starts_with($command->getName(), 'build')) {
-                    unset($commands[$key]);
-                }
-            }
-        } else {
-            // Replace the 'build' command from the build-recipe for the dependent builds specified in the artifact.
-            foreach ($commands as $key => $command) {
-                if (str_starts_with($command->getName(), 'build')) {
-                    unset($commands[$key]);
-                }
-            }
-            // Add the dependent build commands.
-            $dependent_build_commands = [];
-            foreach ($dependent_builds as $target) {
-                $dependent_build_commands[] = new PolymerCommand("build", ['target' => $target]);
-            }
-            $commands = array_merge($dependent_build_commands, $commands);
+        $builder = $this->collectionBuilder($io);
+        foreach ($dependent_builds as $build) {
+            // @phpstan-ignore method.nonObject
+            $command = $application->find('build');
+            // @phpstan-ignore method.notFound
+            $builder
+                ->taskToggleableSymfonyCommand($command)
+                ->arg('target', $build);
         }
-        return $commands;
-    }
+        // @phpstan-ignore method.notFound
+        $builder
+            // @phpstan-ignore method.nonObject
+            ->taskToggleableSymfonyCommand($application->find('source:build:copy'))
+                ->opt('deploy-dir', $deployDir)
+            // @phpstan-ignore method.nonObject
+            ->taskToggleableSymfonyCommand($application->find('artifact:composer:install'))
+            // @phpstan-ignore method.nonObject
+            ->taskToggleableSymfonyCommand($application->find('artifact:build:sanitize'));
+        $result = $builder->run();
 
-    /**
-     * Gather build source and target information.
-     *
-     * @param string $artifact
-     *   The artifact definition to use for the build.
-     *
-     * @throws \Robo\Exception\TaskException
-     */
-    private function loadRecipes(string $artifact): void
-    {
-        $recipe_name = $this->getBuildRecipeName($artifact);
-        $recipe = $this->getBuildRecipe($recipe_name);
-        if ($recipe == null) {
-            throw new TaskException($this, "Recipe '{$recipe_name}' does not exist for the artifact '{$artifact}'.");
-        }
-        $this->buildRecipe = $recipe;
-    }
-
-    /**
-     * Get the build recipe name for the given artifact.
-     *
-     * @param string $artifact
-     *   The artifact definition to use for the build.
-     *
-     * @return string
-     *   The build recipe.
-     */
-    protected function getBuildRecipeName(string $artifact): string
-    {
-        // @phpstan-ignore-next-line
-        return $this->getConfigValue("artifacts.$artifact.build-recipe");
+        $this->invokeHook("post-deploy-build");
+        $this->say("<info>The deployment artifact was generated at {$deployDir}.</info>");
     }
 
     /**
@@ -184,7 +95,7 @@ class CompileCommand extends TaskBase
      * @param string $artifact
      *   The artifact definition to use for the build.
      *
-     * @return array<string, string>
+     * @return array<int, string>
      *   The list of dependent builds to use.
      */
     private function getDependentBuilds(string $artifact): array

--- a/src/Robo/Commands/Artifact/DeployCommand.php
+++ b/src/Robo/Commands/Artifact/DeployCommand.php
@@ -2,6 +2,7 @@
 
 namespace DigitalPolygon\Polymer\Robo\Commands\Artifact;
 
+use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 use Symfony\Component\Console\Input\InputOption;
 use Consolidation\AnnotatedCommand\Attributes\Argument;
 use Consolidation\AnnotatedCommand\Attributes\Command;
@@ -13,15 +14,8 @@ use Robo\Exception\TaskException;
 /**
  * Defines commands in the "artifact:deploy" namespace.
  */
-class DeployCommand extends CompileCommand
+class DeployCommand extends TaskBase
 {
-    /**
-     * The deploy recipe command to use for the requested artifact.
-     *
-     * @var \DigitalPolygon\Polymer\Robo\Recipes\RecipeInterface
-     */
-    protected RecipeInterface $deployRecipe;
-
     /**
      * Builds separate artifact and pushes to 'git.remotes' defined polymer.yml.
      *
@@ -39,51 +33,6 @@ class DeployCommand extends CompileCommand
     #[Option(name: 'dry-run', description: 'Show the deploy operations without pushing the artifact.')]
     public function deployArtifact(string $artifact, array $options = ['branch' => InputOption::VALUE_REQUIRED, 'tag' => InputOption::VALUE_REQUIRED, 'commit-msg' => InputOption::VALUE_REQUIRED, 'dry-run' => false]): void
     {
-        // Gather build source and target information.
-        $this->initialize();
-        // Show start task message.
-        $build_recipe_name = $this->getBuildRecipeName($artifact);
-        $deploy_recipe_name = $this->getDeployRecipeName($artifact);
-        $this->say("Generating and deploying artifact '{$artifact}' using build recipe: '$build_recipe_name' and deploy recipe: '$deploy_recipe_name'...");
-        // Load the deploy recipe for the requested artifact.
-        $this->loadRecipes($artifact);
-        // Collect the deploy commands to execute based on the env context and recipe used.
-        $commands = $this->deployRecipe->getCommands();
-        // Execute the build process.
-        $this->invokeCommands($commands);
-        $this->say("<info>The deployment artifact was generated at {$this->deployDir}.</info>");
-    }
-
-    /**
-     * Loads the push recipe from the artifact.
-     *
-     * @param string $artifact
-     *   The artifact definition to use for the deploy.
-     *
-     * @throws \Robo\Exception\TaskException
-     */
-    private function loadRecipes(string $artifact): void
-    {
-        $recipe_name = $this->getDeployRecipeName($artifact);
-        $recipe = $this->getPushRecipe($recipe_name);
-        if ($recipe == null) {
-            throw new TaskException($this, "Recipe '{$recipe_name}' does not exist for the artifact '{$artifact}'.");
-        }
-        $this->deployRecipe = $recipe;
-    }
-
-    /**
-     * Get the deploy recipe name for the given artifact.
-     *
-     * @param string $artifact
-     *   The artifact definition to use for the build.
-     *
-     * @return string
-     *   The deploy recipe name.
-     */
-    private function getDeployRecipeName(string $artifact): string
-    {
-        // @phpstan-ignore-next-line
-        return $this->getConfigValue("artifacts.$artifact.push-recipe");
+        $this->say("Deploying artifact '{$artifact}'...");
     }
 }

--- a/src/Robo/Commands/Artifact/DeployCommand.php
+++ b/src/Robo/Commands/Artifact/DeployCommand.php
@@ -2,24 +2,54 @@
 
 namespace DigitalPolygon\Polymer\Robo\Commands\Artifact;
 
+use Consolidation\AnnotatedCommand\Attributes\Hook;
+use DigitalPolygon\Polymer\Robo\ConsoleApplication;
+use DigitalPolygon\Polymer\Robo\Exceptions\PolymerException;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
+use Robo\Contract\VerbosityThresholdInterface;
+use Robo\Symfony\ConsoleIO;
 use Symfony\Component\Console\Input\InputOption;
 use Consolidation\AnnotatedCommand\Attributes\Argument;
 use Consolidation\AnnotatedCommand\Attributes\Command;
 use Consolidation\AnnotatedCommand\Attributes\Option;
 use Consolidation\AnnotatedCommand\Attributes\Usage;
-use DigitalPolygon\Polymer\Robo\Recipes\RecipeInterface;
-use Robo\Exception\TaskException;
 
 /**
  * Defines commands in the "artifact:deploy" namespace.
  */
 class DeployCommand extends TaskBase
 {
+    protected string $excludeFileTemp;
+    protected mixed $deployDir;
+    protected mixed $deployDocroot;
+    protected mixed $tagSource;
+    protected string $branchName;
+    /**
+     * @var mixed|string
+     */
+    protected mixed $commitMessage;
+
+    /**
+     * This hook will fire for all commands in this command file.
+     *
+     * @throws \DigitalPolygon\Polymer\Robo\Exceptions\PolymerException
+     */
+    #[Hook(type: 'init')]
+    public function initialize(): void
+    {
+        $this->excludeFileTemp = $this->getConfigValue('deploy.exclude_file') . '.tmp';
+        $this->deployDir = $this->getConfigValue('deploy.dir');
+        $this->deployDocroot = $this->getConfigValue('deploy.docroot');
+        if (!$this->deployDir || !$this->deployDocroot) {
+            throw new PolymerException('Configuration deploy.dir and deploy.docroot must be set to run this command');
+        }
+        $this->tagSource = $this->getConfigValue('deploy.tag_source', true);
+    }
+
     /**
      * Builds separate artifact and pushes to 'git.remotes' defined polymer.yml.
      *
-     * @param array<string, int|false> $options
+     * @param array<string, int|false|string> $options
      *   The artifact deploy command options.
      *
      * @throws \Robo\Exception\TaskException|\Robo\Exception\AbortTasksException
@@ -31,8 +61,245 @@ class DeployCommand extends TaskBase
     #[Option(name: 'tag', description: 'The tag name.')]
     #[Option(name: 'commit-msg', description: 'The commit message.')]
     #[Option(name: 'dry-run', description: 'Show the deploy operations without pushing the artifact.')]
-    public function deployArtifact(string $artifact, array $options = ['branch' => InputOption::VALUE_REQUIRED, 'tag' => InputOption::VALUE_REQUIRED, 'commit-msg' => InputOption::VALUE_REQUIRED, 'dry-run' => false]): void
+    public function deployArtifact(ConsoleIO $io, string $artifact, array $options = ['branch' => InputOption::VALUE_REQUIRED, 'tag' => InputOption::VALUE_REQUIRED, 'commit-msg' => InputOption::VALUE_REQUIRED, 'dry-run' => false]): void
     {
+        $this->branchName = $this->getBranchName($options);
+        $this->prepareDir();
+        $this->addGitRemotes();
+        $this->checkoutLocalDeployBranch();
+        $this->mergeUpstreamChanges();
+        /** @var ConsoleApplication $application */
+        $application = $this->getContainer()->get('application');
+        $this->commitMessage = $this->getCommitMessage($options);
+
         $this->say("Deploying artifact '{$artifact}'...");
+
+        $builder = $this->collectionBuilder($io);
+        $builder
+            ->taskToggleableSymfonyCommand($application->find('artifact:compile'))
+                ->arg('artifact', $artifact)
+            ->taskGitStack()
+                ->dir($this->deployDir)
+                ->exec("git rm -r --cached --ignore-unmatch --quiet .")
+                ->add('-A')
+                ->commit($this->commitMessage, '--quiet')
+                ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+            ->taskExecStack()
+                ->dir($this->deployDir);
+        /** @var array<int|string,string> $remotes */
+        $remotes = $this->getConfigValue('git.remotes');
+        foreach ($remotes as $remote) {
+            $remote_name = md5($remote);
+            $builder->exec("git push $remote_name $this->branchName");
+        }
+
+        $result = $builder->run();
+    }
+
+    /**
+     * Gets the branch name for the deployment artifact.
+     *
+     * @param array<string, int|string|false> $options
+     *   CLI options for command.
+     *
+     * @return string
+     *   The branch name.
+     */
+    protected function getBranchName($options): string
+    {
+        if (is_string($options['branch']) && $options['branch']) {
+            $this->say("Branch is set to <comment>{$options['branch']}</comment>.");
+            return $options['branch'];
+        } else {
+            return $this->askDefault('Enter the branch name for the deployment artifact', $this->getDefaultBranchName());
+        }
+    }
+
+    protected function getDefaultBranchName(): string
+    {
+        /** @var string $repoRoot */
+        $repoRoot = $this->getConfigValue('repo.root');
+        chdir($repoRoot);
+        $branchName = shell_exec("git rev-parse --abbrev-ref HEAD");
+        if (is_string($branchName)) {
+            $gitCurrentBranch = trim($branchName);
+            $defaultBranch = $gitCurrentBranch . '-build';
+            return $defaultBranch;
+        }
+        throw new PolymerException('Failed to get current branch name.');
+    }
+
+    /**
+     * Deletes the existing deploy directory and initializes git repo.
+     *
+     * @throws \Exception
+     * @throws \Robo\Exception\TaskException
+     */
+    protected function prepareDir(): void
+    {
+        $this->say("Preparing artifact directory...");
+        $deploy_dir = $this->deployDir;
+        if (is_string($deploy_dir)) {
+            $this->taskDeleteDir($deploy_dir)
+                ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+                ->run();
+            $result = $this->taskFilesystemStack()
+                ->mkdir($this->deployDir)
+                ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+                ->run();
+            if (!$result->wasSuccessful()) {
+                throw new PolymerException('Failed to create deploy directory');
+            }
+            $result = $this->taskExecStack()
+                ->dir($deploy_dir)
+                ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+                ->exec("git init")
+                ->exec("git config --local core.excludesfile false")
+                ->exec("git config --local core.fileMode true")
+                ->run();
+            if (!$result->wasSuccessful()) {
+                throw new PolymerException('Failed to initialize git repo');
+            }
+            $this->say("Global .gitignore file is being disabled for this repository to prevent unexpected behavior.");
+            return;
+        }
+        throw new PolymerException('Deploy directory is not valid.');
+    }
+
+    /**
+     * Adds remotes from git.remotes to /deploy repository.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    protected function addGitRemotes(): void
+    {
+        /** @var array<int|string,string> $git_remotes */
+        $git_remotes = $this->getConfigValue('git.remotes');
+        if (empty($git_remotes)) {
+            throw new PolymerException("git.remotes is empty. Please define at least one value for git.remotes in blt/blt.yml.");
+        }
+        foreach ($git_remotes as $remote_url) {
+            $this->addGitRemote($remote_url);
+        }
+    }
+
+    /**
+     * Adds a single remote to the /deploy repository.
+     *
+     * @param string $remote_url
+     *   Remote URL.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    protected function addGitRemote($remote_url): void
+    {
+        // Generate an md5 sum of the remote URL to use as remote name.
+        $remote_name = md5($remote_url);
+        $result = $this->taskExecStack()
+            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+            ->dir($this->deployDir)
+            ->exec("git remote add $remote_name $remote_url")
+            ->run();
+        if (!$result->wasSuccessful()) {
+            throw new PolymerException('Failed to add remote');
+        }
+    }
+
+    /**
+     * Checks out a new, local branch for artifact.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    protected function checkoutLocalDeployBranch(): void
+    {
+        $result = $this->taskExecStack()
+            ->dir($this->deployDir)
+            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+            ->exec("git checkout -b {$this->branchName}")
+            ->run();
+        if (!$result->wasSuccessful()) {
+            throw new PolymerException('Failed to check out branch');
+        }
+    }
+
+    /**
+     * Merges upstream changes into deploy branch.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    protected function mergeUpstreamChanges(): void
+    {
+        /** @var array<string|int,string> $git_remotes */
+        $git_remotes = $this->getConfigValue('git.remotes');
+        /** @var string $remote_url */
+        $remote_url = reset($git_remotes);
+        $remote_name = md5($remote_url);
+
+        $this->say("Merging upstream changes into local artifact...");
+
+        // Check if remote branch exists before fetching.
+        $result = $this->taskExecStack()
+            ->dir($this->deployDir)
+            ->stopOnFail(false)
+            ->exec("git ls-remote --exit-code --heads $remote_url {$this->branchName}")
+            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+            ->run();
+        switch ($result->getExitCode()) {
+            case 0:
+                // The remote branch exists, continue and merge it.
+                break;
+
+            case 2:
+                // The remote branch doesn't exist, bail out.
+                return;
+
+            default:
+                // Some other error code.
+                throw new PolymerException("Unexpected error while searching for remote branch: " . $result->getMessage());
+        }
+
+        // Now we know the remote branch exists, let's fetch and merge it.
+        $result = $this->taskExecStack()
+            ->dir($this->deployDir)
+            ->exec("git fetch $remote_name {$this->branchName} --depth=1")
+            ->exec("git merge $remote_name/{$this->branchName}")
+            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+            ->run();
+        if (!$result->wasSuccessful()) {
+            throw new PolymerException('Failed to merge branch');
+        }
+    }
+
+    /**
+     * Gets the commit message to be used for committing deployment artifact.
+     *
+     * Defaults to the last commit message on the source branch.
+     *
+     * @param array<string,int|string|false> $options
+     *   CLI options for command.
+     *
+     * @return mixed
+     *   The commit message.
+     */
+    protected function getCommitMessage(array $options)
+    {
+        if (!$options['commit-msg']) {
+            $gitLastCommitMessage = '';
+            $repoRoot = $this->getConfigValue('repo.root');
+            if (is_string($repoRoot)) {
+                chdir($repoRoot);
+                $log = shell_exec("git log --oneline -1");
+                if (is_string($log)) {
+                    $log = explode(' ', $log, 2);
+                    $gitLastCommitMessage = trim($log[1]);
+                }
+            }
+
+
+            return $this->askDefault('Enter a valid commit message', $gitLastCommitMessage);
+        } else {
+            $this->say("Commit message is set to <comment>{$options['commit-msg']}</comment>.");
+            return $options['commit-msg'];
+        }
     }
 }

--- a/src/Robo/Common/ArrayManipulator.php
+++ b/src/Robo/Common/ArrayManipulator.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Common;
+
+use Dflydev\DotAccessData\Data;
+
+/**
+ * Utility class for manipulating arrays.
+ */
+class ArrayManipulator
+{
+    /**
+     * Merges arrays recursively while preserving.
+     *
+     * @param array $array1
+     *   The first array.
+     * @param array $array2
+     *   The second array.
+     *
+     * @return array
+     *   The merged array.
+     *
+     * @see http://php.net/manual/en/function.array-merge-recursive.php#92195
+     */
+    public static function arrayMergeRecursiveDistinct(
+        array &$array1,
+        array &$array2,
+    ) {
+        $merged = $array1;
+        foreach ($array2 as $key => &$value) {
+            if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
+                $merged[$key] = self::arrayMergeRecursiveDistinct(
+                    $merged[$key],
+                    $value
+                );
+            } else {
+                $merged[$key] = $value;
+            }
+        }
+        return $merged;
+    }
+
+    /**
+     * Converts dot-notated keys to proper associative nested keys.
+     *
+     * E.g., [drush.alias => 'self'] would be expanded to
+     * ['drush' => ['alias' => 'self']]
+     *
+     * @param array $array
+     *   The array containing unexpanded dot-notated keys.
+     *
+     * @return array
+     *   The expanded array.
+     */
+    public static function expandFromDotNotatedKeys(array $array)
+    {
+        $data = new Data();
+
+        // @todo Make this work at all levels of array.
+        foreach ($array as $key => $value) {
+            $data->set($key, $value);
+        }
+
+        return $data->export();
+    }
+
+    /**
+     * Flattens a multidimensional array to a flat array with dot-notated keys.
+     *
+     * This is the inverse of expandFromDotNotatedKeys(), e.g.,
+     * ['drush' => ['alias' => 'self']] would be flattened to
+     * [drush.alias => 'self'].
+     *
+     * @param array<string, array> $array
+     *   The multidimensional array.
+     *
+     * @return array<string, mixed>
+     *   The flattened array.
+     */
+    public static function flattenToDotNotatedKeys(array $array)
+    {
+        return self::flattenMultidimensionalArray($array, '.');
+    }
+
+    /**
+     * Flattens a multidimensional array to a flat array, using custom glue.
+     *
+     * This is the inverse of expandFromDotNotatedKeys(), e.g.,
+     * ['drush' => ['alias' => 'self']] would be flattened to
+     * [drush.alias => 'self'].
+     *
+     * @param array<string, array<string,string>|bool> $array
+     *   The multidimensional array.
+     * @param string $glue
+     *   The character(s) to use for imploding keys.
+     *
+     * @return array<string, mixed>
+     *   The flattened array.
+     */
+    public static function flattenMultidimensionalArray(array $array, $glue): array
+    {
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($array));
+        $result = [];
+        foreach ($iterator as $leafValue) {
+            $keys = [];
+            foreach (range(0, $iterator->getDepth()) as $depth) {
+                $keys[] = $iterator->getSubIterator($depth)->key();
+            }
+            $result[implode($glue, $keys)] = $leafValue;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Converts a multi-dimensional array to a human-readable flat array.
+     *
+     * Used primarily for rendering tables via Symfony Console commands.
+     *
+     * @param array<mixed, mixed> $array
+     *   The multi-dimensional array.
+     *
+     * @return array<int<0, max>, array<int, int|string>>
+     *   The human-readble, flat array.
+     */
+    public static function convertArrayToFlatTextArray(array $array)
+    {
+        $rows = [];
+        $max_line_length = 60;
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $flattened_array = self::flattenToDotNotatedKeys($value);
+                foreach ($flattened_array as $sub_key => $sub_value) {
+                    if ($sub_value === true) {
+                        $sub_value = 'true';
+                    } elseif ($sub_value === false) {
+                        $sub_value = 'false';
+                    } elseif (!is_string($sub_value) || $sub_value === null) {
+                        $sub_value = '';
+                    }
+                    $rows[] = [
+                        "$key.$sub_key",
+                        wordwrap($sub_value, $max_line_length, "\n", true),
+                    ];
+                }
+            } else {
+                if ($value === true) {
+                    $contents = 'true';
+                } elseif ($value === false) {
+                    $contents = 'false';
+                } elseif ($value === null || !is_string($value)) {
+                    $contents = '';
+                } else {
+                    $contents = wordwrap($value, $max_line_length, "\n", true);
+                }
+                $rows[] = [$key, $contents];
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/src/Robo/Config/ConfigAwareTrait.php
+++ b/src/Robo/Config/ConfigAwareTrait.php
@@ -16,7 +16,7 @@ trait ConfigAwareTrait
      *
      * @param string $key
      *   The config key.
-     * @param string|null $default
+     * @param mixed $default
      *   The default value if the key does not exist in config.
      *
      * @return mixed
@@ -24,6 +24,7 @@ trait ConfigAwareTrait
      */
     protected function getConfigValue($key, $default = null): mixed
     {
+        // @phpstan-ignore argument.type
         return $this->getConfig()->get($key, $default) ?? $default;
     }
 

--- a/src/Robo/Polymer.php
+++ b/src/Robo/Polymer.php
@@ -12,6 +12,7 @@ use DigitalPolygon\Polymer\Robo\Discovery\PushRecipesDiscovery;
 use League\Container\Container;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
+use Robo\Contract\ConfigAwareInterface;
 use Robo\Robo;
 use Robo\Runner as RoboRunner;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * The Polymer Robo application.
  */
-class Polymer implements ContainerAwareInterface
+class Polymer implements ContainerAwareInterface, ConfigAwareInterface
 {
     use ContainerAwareTrait;
     use ConfigAwareTrait;

--- a/src/Robo/Recipes/Build/BuildRecipeBase.php
+++ b/src/Robo/Recipes/Build/BuildRecipeBase.php
@@ -12,7 +12,6 @@ use Robo\Contract\ConfigAwareInterface;
  */
 abstract class BuildRecipeBase implements RecipeInterface, ConfigAwareInterface
 {
-    use ConfigAwareTrait;
     use DeployConfigAwareTrait;
 
     /**

--- a/src/Robo/Recipes/Build/BuildRecipeBase.php
+++ b/src/Robo/Recipes/Build/BuildRecipeBase.php
@@ -2,7 +2,6 @@
 
 namespace DigitalPolygon\Polymer\Robo\Recipes\Build;
 
-use DigitalPolygon\Polymer\Robo\Config\ConfigAwareTrait;
 use DigitalPolygon\Polymer\Robo\Recipes\DeployConfigAwareTrait;
 use DigitalPolygon\Polymer\Robo\Recipes\RecipeInterface;
 use Robo\Contract\ConfigAwareInterface;

--- a/src/Robo/Recipes/Build/CommonBuildRecipe.php
+++ b/src/Robo/Recipes/Build/CommonBuildRecipe.php
@@ -29,7 +29,11 @@ class CommonBuildRecipe extends BuildRecipeBase
         // Ensure frontend is build in the artifact directory.
         $commands[] = new PolymerCommand('build');
         // Copy files from the source repository into the artifact.
-        $commands[] = new PolymerCommand('source:build:copy', ['--deploy-dir' => $this->deployDir]);
+        $buildCopyOptions = [];
+        if ($this->deployDir) {
+            $buildCopyOptions['--deploy-dir'] = $this->deployDir;
+        }
+        $commands[] = new PolymerCommand('source:build:copy', $buildCopyOptions);
         // Install Composer dependencies for the artifact.
         $commands[] = new PolymerCommand('artifact:composer:install');
         // Remove sensitive files from the artifact directory.

--- a/src/Robo/Recipes/DeployConfigAwareTrait.php
+++ b/src/Robo/Recipes/DeployConfigAwareTrait.php
@@ -2,6 +2,7 @@
 
 namespace DigitalPolygon\Polymer\Robo\Recipes;
 
+use DigitalPolygon\Polymer\Robo\Config\ConfigAwareTrait;
 use Robo\Exception\TaskException;
 
 /**
@@ -9,19 +10,17 @@ use Robo\Exception\TaskException;
  */
 trait DeployConfigAwareTrait
 {
+    use ConfigAwareTrait;
+
     /**
      * Deploy directory.
-     *
-     * @var string
      */
-    protected string $deployDir;
+    protected ?string $deployDir = null;
 
     /**
      * Deploy docroot directory.
-     *
-     * @var string
      */
-    protected string $deployDocroot;
+    protected ?string $deployDocroot = null;
 
     /**
      * Gather build source and target information.
@@ -30,10 +29,14 @@ trait DeployConfigAwareTrait
      */
     protected function initialize(): void
     {
-        // @phpstan-ignore-next-line
-        $this->deployDir = $this->getConfigValue('deploy.dir');
-        // @phpstan-ignore-next-line
-        $this->deployDocroot = $this->getConfigValue('deploy.docroot');
+        $deployDir = $this->getConfigValue('deploy.dir');
+        if (is_string($deployDir)) {
+            $this->deployDir = $deployDir;
+        }
+        $deployDocroot = $this->getConfigValue('deploy.docroot');
+        if (is_string($deployDocroot)) {
+            $this->deployDocroot = $deployDocroot;
+        }
         if (!$this->deployDir || !$this->deployDocroot) {
             throw new TaskException($this, 'Configuration deploy.dir and deploy.docroot must be set to run this command');
         }

--- a/src/Robo/Recipes/Push/GitRemotePushRecipe.php
+++ b/src/Robo/Recipes/Push/GitRemotePushRecipe.php
@@ -268,10 +268,12 @@ class GitRemotePushRecipe extends PushRecipeBase
     private function getPrepareDirCommands(): array
     {
         $commands = [];
-        $commands[] = new PolymerCommand('artifact:build:prepare');
-        $commands[] = new PolymerCommand('git init', ['dir' => $this->deployDir], false);
-        $commands[] = new PolymerCommand('git config --local core.excludesfile false', ['dir' => $this->deployDir], false);
-        $commands[] = new PolymerCommand('git config --local core.fileMode true', ['dir' => $this->deployDir], false);
+        if ($this->deployDir) {
+            $commands[] = new PolymerCommand('artifact:build:prepare');
+            $commands[] = new PolymerCommand('git init', ['dir' => $this->deployDir], false);
+            $commands[] = new PolymerCommand('git config --local core.excludesfile false', ['dir' => $this->deployDir], false);
+            $commands[] = new PolymerCommand('git config --local core.fileMode true', ['dir' => $this->deployDir], false);
+        }
         return $commands;
     }
 
@@ -284,9 +286,11 @@ class GitRemotePushRecipe extends PushRecipeBase
     private function getAddGitRemotesCommands(): array
     {
         $commands = [];
-        foreach ($this->remotes as $remote_name => $remote_url) {
-            $command_string = "git remote add $remote_name $remote_url";
-            $commands[] = new PolymerCommand($command_string, ['dir' => $this->deployDir], false);
+        if ($this->deployDir) {
+            foreach ($this->remotes as $remote_name => $remote_url) {
+                $command_string = "git remote add $remote_name $remote_url";
+                $commands[] = new PolymerCommand($command_string, ['dir' => $this->deployDir], false);
+            }
         }
         return $commands;
     }
@@ -300,7 +304,9 @@ class GitRemotePushRecipe extends PushRecipeBase
     private function getCheckoutLocalDeployBranchCommands(): array
     {
         $commands = [];
-        $commands[] = new PolymerCommand("git checkout -b {$this->branchName}", ['dir' => $this->deployDir], false);
+        if ($this->deployDir) {
+            $commands[] = new PolymerCommand("git checkout -b {$this->branchName}", ['dir' => $this->deployDir], false);
+        }
         return $commands;
     }
 
@@ -326,9 +332,11 @@ class GitRemotePushRecipe extends PushRecipeBase
     private function getCommitCommands(): array
     {
         $commands = [];
-        $commands[] = new PolymerCommand('git rm -r --cached --ignore-unmatch --quiet .', ['dir' => $this->deployDir], false);
-        $commands[] = new PolymerCommand('git add -A', ['dir' => $this->deployDir], false);
-        $commands[] = new PolymerCommand($this->getGitCommitCommandString(), ['dir' => $this->deployDir], false);
+        if ($this->deployDir) {
+            $commands[] = new PolymerCommand('git rm -r --cached --ignore-unmatch --quiet .', ['dir' => $this->deployDir], false);
+            $commands[] = new PolymerCommand('git add -A', ['dir' => $this->deployDir], false);
+            $commands[] = new PolymerCommand($this->getGitCommitCommandString(), ['dir' => $this->deployDir], false);
+        }
         return $commands;
     }
 
@@ -341,7 +349,9 @@ class GitRemotePushRecipe extends PushRecipeBase
     private function getCutTagCommands(): array
     {
         $commands = [];
-        $commands[] = new PolymerCommand($this->getGitTagCommandString(), ['dir' => $this->deployDir], false);
+        if ($this->deployDir) {
+            $commands[] = new PolymerCommand($this->getGitTagCommandString(), ['dir' => $this->deployDir], false);
+        }
         return $commands;
     }
 
@@ -357,9 +367,11 @@ class GitRemotePushRecipe extends PushRecipeBase
     private function getPushCommands(string $identifier): array
     {
         $commands = [];
-        $dry_run = $this->dryRun ? '--dry-run' : '';
-        foreach ($this->remotes as $remote_name => $remote_url) {
-            $commands[] = new PolymerCommand("git push {$remote_name} {$identifier} {$dry_run}", ['dir' => $this->deployDir], false);
+        if ($this->deployDir) {
+            $dry_run = $this->dryRun ? '--dry-run' : '';
+            foreach ($this->remotes as $remote_name => $remote_url) {
+                $commands[] = new PolymerCommand("git push {$remote_name} {$identifier} {$dry_run}", ['dir' => $this->deployDir], false);
+            }
         }
         return $commands;
     }

--- a/src/Robo/Recipes/Push/PushRecipeBase.php
+++ b/src/Robo/Recipes/Push/PushRecipeBase.php
@@ -16,7 +16,6 @@ use Robo\Contract\IOAwareInterface;
  */
 abstract class PushRecipeBase implements RecipeInterface, ConfigAwareInterface, LoggerAwareInterface, IOAwareInterface
 {
-    use ConfigAwareTrait;
     use LoggerAwareTrait;
     use IO;
     use DeployConfigAwareTrait;

--- a/src/Robo/Recipes/Push/PushRecipeBase.php
+++ b/src/Robo/Recipes/Push/PushRecipeBase.php
@@ -2,7 +2,6 @@
 
 namespace DigitalPolygon\Polymer\Robo\Recipes\Push;
 
-use DigitalPolygon\Polymer\Robo\Config\ConfigAwareTrait;
 use DigitalPolygon\Polymer\Robo\Recipes\DeployConfigAwareTrait;
 use DigitalPolygon\Polymer\Robo\Recipes\RecipeInterface;
 use Psr\Log\LoggerAwareInterface;

--- a/src/Robo/Tasks/TaskBase.php
+++ b/src/Robo/Tasks/TaskBase.php
@@ -9,7 +9,6 @@ use Robo\Contract\BuilderAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\LoadAllTasks;
 use Robo\Result;
-use Robo\Tasks;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
 use Robo\Exception\TaskException;
@@ -245,5 +244,15 @@ abstract class TaskBase implements ConfigAwareInterface, LoggerAwareInterface, B
         // Replaces config.
         // @phpstan-ignore-next-line
         $this->getConfig()->replace($new_config->export());
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Command\Command $command
+     *
+     * @return \DigitalPolygon\Polymer\Robo\Tasks\ToggleableSymfonyCommand|\Robo\Collection\CollectionBuilder
+     */
+    public function taskToggleableSymfonyCommand($command)
+    {
+        return $this->task(ToggleableSymfonyCommand::class, $command);
     }
 }

--- a/src/Robo/Tasks/ToggleableSymfonyCommand.php
+++ b/src/Robo/Tasks/ToggleableSymfonyCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Tasks;
+
+use DigitalPolygon\Polymer\Robo\Common\ArrayManipulator;
+use DigitalPolygon\Polymer\Robo\Config\ConfigAwareTrait;
+use Robo\Result;
+use Robo\Task\Base\SymfonyCommand;
+
+class ToggleableSymfonyCommand extends SymfonyCommand
+{
+    use ConfigAwareTrait;
+
+    public function run()
+    {
+        $commandName = $this->command->getName();
+        if (is_string($commandName) && !$this->isCommandDisabled($commandName)) {
+            return parent::run();
+        }
+        // A disabled command should not result in failure, so use exit code 0.
+        return new Result($this, 0);
+    }
+
+    /**
+     * Gets an array of commands that have been configured to be disabled.
+     *
+     * @return array<int|string, mixed>
+     *   A flat array of disabled commands.
+     */
+    protected function getDisabledCommands(): array
+    {
+        /** @var array<string, array<string, string>|bool> $disabled_commands_config */
+        $disabled_commands_config = $this->getConfigValue('disable-targets');
+        if ($disabled_commands_config) {
+            $disabled_commands = ArrayManipulator::flattenMultidimensionalArray($disabled_commands_config, ':');
+            return $disabled_commands;
+        }
+        return [];
+    }
+
+    /**
+     * Determines if a command has been disabled via disable-targets.
+     *
+     * @param string $command
+     *   The command name.
+     *
+     * @return bool
+     *   TRUE if the command is disabled.
+     */
+    protected function isCommandDisabled(string $command)
+    {
+        $disabled_commands = $this->getDisabledCommands();
+        if (is_array($disabled_commands) && array_key_exists($command, $disabled_commands) && $disabled_commands[$command]) {
+            $this->logger?->warning("The $command command is disabled.");
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
# Changes

- Removes recipe concept temporarily. I want to pursue pluggability while also leveraging more core Robo features, primarily tasks and collection builders.
- Ensures that artifact branch deployments have external changes brought down first before copying over build artifact to then commit, merge, and push.