### PR TITLE
Fixes the broken drupal docroot intialization.

### DIFF
--- a/src/Robo/Config/DefaultConfig.php
+++ b/src/Robo/Config/DefaultConfig.php
@@ -32,21 +32,10 @@ class DefaultConfig extends Config
      *
      * @return string
      *   The filepath for the drupal root.
-     *
-     * @throws \Exception
      */
     private function getDrupalRoot(string $repo_root): string
     {
-        $possible_drupal_repo_roots = [
-            $repo_root . '/docroot',
-            $repo_root . '/web',
-        ];
-        foreach ($possible_drupal_repo_roots as $possible_drupal_repo_root) {
-            if (file_exists($possible_drupal_repo_root)) {
-                return $possible_drupal_repo_root;
-            }
-        }
-        throw new \Exception('Could not find the drupal root directory.');
+        return file_exists($repo_root . '/docroot') ? $repo_root . '/docroot' : $repo_root . '/web';
     }
 
     /**


### PR DESCRIPTION
## Problem/Motivation

1. GH actions are failing for - https://github.com/digitalpolygon/polymer-drupal/pull/7. Since it's not able to find the drupal docroot path.
2. Improved the error and default value handling in `getDrupalRoot`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified logic for determining the Drupal root directory, improving reliability in locating the `docroot`.
	- Adjusted error handling behavior related to directory existence checks.

- **Documentation**
	- Updated method documentation to reflect changes in error handling for the `getDrupalRoot` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->