### PR TITLE
Allow to add global options to any polymer command.

### DIFF
--- a/src/Robo/Config/ConfigInitializer.php
+++ b/src/Robo/Config/ConfigInitializer.php
@@ -103,6 +103,7 @@ class ConfigInitializer
         $this->loadDefaultConfig();
         $this->loadDefaultPolymerExtensionConfigs();
         $this->loadProjectConfig();
+        $this->loadSiteConfig();
         return $this;
     }
 
@@ -130,6 +131,23 @@ class ConfigInitializer
         $this->processor->extend(
             $this->loader->load($this->config->get('repo.root') . "/polymer/{$this->environment}.polymer.yml")
         );
+        return $this;
+    }
+
+    /**
+     * Load site specific config.
+     *
+     * @return $this
+     */
+    public function loadSiteConfig()
+    {
+        if ($this->site) {
+            // Since docroot can change in the project, we need to respect that here.
+            $this->config->replace($this->processor->export());
+            $this->processor->extend($this->loader->load($this->config->get('docroot') . "/sites/{$this->site}/polymer.yml"));
+            $this->processor->extend($this->loader->load($this->config->get('docroot') . "/sites/{$this->site}/{$this->environment}.polymer.yml"));
+        }
+
         return $this;
     }
 

--- a/src/Robo/Polymer.php
+++ b/src/Robo/Polymer.php
@@ -16,6 +16,7 @@ use Robo\Contract\ConfigAwareInterface;
 use Robo\Robo;
 use Robo\Runner as RoboRunner;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -81,6 +82,7 @@ class Polymer implements ContainerAwareInterface, ConfigAwareInterface
         // Create and configure container.
         $container = new Container();
         Robo::configureContainer($container, $application, $config, $input, $output, $classLoader);
+        $this->addDefaultArgumentsAndOptions($application);
         $this->configureContainer($container);
         $this->registerRecipes($container);
         Robo::finalizeContainer($container);
@@ -112,6 +114,28 @@ class Polymer implements ContainerAwareInterface, ConfigAwareInterface
         /** @var \Robo\Application $application */
         $application = $this->getContainer()->get('application');
         return $this->runner->run($input, $output, $application, $this->commands);
+    }
+
+    /**
+     * Add any global arguments or options that apply to all commands.
+     *
+     * @param \DigitalPolygon\Polymer\Robo\ConsoleApplication $app
+     *   The Symfony application.
+     */
+    private function addDefaultArgumentsAndOptions(ConsoleApplication $app): void
+    {
+        $app->getDefinition()
+        ->addOption(
+            new InputOption('--define', '-D', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Define a configuration item value.', [])
+        );
+        $app->getDefinition()
+        ->addOption(
+            new InputOption('--environment', null, InputOption::VALUE_REQUIRED, 'Set the environment to load config from polymer/[env].yml file.', [])
+        );
+        $app->getDefinition()
+        ->addOption(
+            new InputOption('--site', null, InputOption::VALUE_REQUIRED, 'The multisite to execute this command against.', [])
+        );
     }
 
     /**

--- a/src/Robo/Tasks/TaskBase.php
+++ b/src/Robo/Tasks/TaskBase.php
@@ -2,23 +2,24 @@
 
 namespace DigitalPolygon\Polymer\Robo\Tasks;
 
-use League\Container\ContainerAwareInterface;
-use League\Container\ContainerAwareTrait;
-use Robo\Collection\CollectionBuilder;
-use Robo\Common\IO;
-use Robo\Contract\BuilderAwareInterface;
-use Robo\Contract\IOAwareInterface;
-use Robo\LoadAllTasks;
 use Robo\Result;
+use Robo\Common\IO;
+use Robo\LoadAllTasks;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
 use Robo\Exception\TaskException;
+use Robo\Contract\IOAwareInterface;
+use Robo\Collection\CollectionBuilder;
 use Robo\Contract\ConfigAwareInterface;
 use Robo\Exception\AbortTasksException;
+use Robo\Contract\BuilderAwareInterface;
+use League\Container\ContainerAwareTrait;
+use League\Container\ContainerAwareInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use DigitalPolygon\Polymer\Robo\Config\ConfigAwareTrait;
-use DigitalPolygon\Polymer\Robo\Config\ConfigInitializer;
 use DigitalPolygon\Polymer\Robo\Recipes\RecipeInterface;
+use DigitalPolygon\Polymer\Robo\Config\ConfigInitializer;
+use DigitalPolygon\Polymer\Environment\AcquiaEnvironmentDetector;
 
 /**
  * Utility base class for Polymer commands.
@@ -79,7 +80,9 @@ abstract class TaskBase implements ConfigAwareInterface, LoggerAwareInterface, B
         // Find the task and format its inputs.
         $task = $application->find($command->getName());
         $input = new ArrayInput($command->getArgs());
-        $input->setInteractive($this->input()->isInteractive());
+        /** @var bool $is_interactive */
+        $is_interactive = (AcquiaEnvironmentDetector::isCiEnv()) ? false : $this->input()->isInteractive();
+        $input->setInteractive($is_interactive);
         // Now run the command.
         $this->output->writeln("   <comment>$command_string</comment>");
         $exit_code = $application->runCommand($task, $input, $this->output());


### PR DESCRIPTION
### Problem/Motivation
1. Allow to add any global arguments or options that apply to all commands.
2. Following are the global options
   - `--define` 
   - `--environment` 
   - `--site` 

### For reference:
![image](https://github.com/user-attachments/assets/a6754fb7-967a-4d07-9903-f09fc86f63e8)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new command-line options (`--define`, `--environment`, `--site`) for enhanced configuration in the Polymer application.
	- Added a method to load site-specific configuration files, improving the configuration process based on site and environment.

- **Bug Fixes**
	- Enhanced control flow for command execution based on the environment, ensuring proper handling of interactive states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->