### PR TITLE
PWT-109: Refactor config loader mechanism

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
     ignoreErrors:
         -
             message: "#^Parameter \\#2 \\$default of method Consolidation\\\\Config\\\\Util\\\\ConfigOverlay\\:\\:get\\(\\) expects string\\|null, array given\\.$#"
+        -
+            identifier: missingType.iterableValue
 #services:
 #    -
 #        class: DigitalPolygon\PolymerTest\PHPStan\CollectionBuilderReflectionExtension

--- a/src/Robo/Config/ConfigManager.php
+++ b/src/Robo/Config/ConfigManager.php
@@ -9,30 +9,35 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 
-class ConfigManager {
-
+class ConfigManager
+{
     public function __construct(
         protected EventDispatcherInterface $dispatcher,
         protected ConfigStack $config,
-    ) {}
+    ) {
+    }
 
-    public function collectContextData(Command $command, InputInterface $input): array {
+    public function collectContextData(Command $command, InputInterface $input): array
+    {
         $event = new CollectConfigContextsEvent($command, $input);
         $this->dispatcher->dispatch($event);
         return $event->getContexts();
     }
 
-    public function alterContextData(array $contexts, Command $command): array {
+    public function alterContextData(array $contexts, Command $command): array
+    {
         $event = new AlterConfigContextsEvent($contexts, $command);
         $this->dispatcher->dispatch($event);
         return $event->getContexts();
     }
 
-    public function pushConfig(PolymerConfig $config): void {
+    public function pushConfig(PolymerConfig $config): void
+    {
         $this->config->pushConfig($config);
     }
 
-    public function popConfig(): ConfigInterface|null {
+    public function popConfig(): ConfigInterface|null
+    {
         return $this->config->popConfig();
     }
 }

--- a/src/Robo/Config/ConfigManager.php
+++ b/src/Robo/Config/ConfigManager.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Config;
+
+use Consolidation\Config\ConfigInterface;
+use DigitalPolygon\Polymer\Robo\Event\AlterConfigContextsEvent;
+use DigitalPolygon\Polymer\Robo\Event\CollectConfigContextsEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class ConfigManager {
+
+    public function __construct(
+        protected EventDispatcherInterface $dispatcher,
+        protected ConfigStack $config,
+    ) {}
+
+    public function collectContextData(Command $command, InputInterface $input): array {
+        $event = new CollectConfigContextsEvent($command, $input);
+        $this->dispatcher->dispatch($event);
+        return $event->getContexts();
+    }
+
+    public function alterContextData(array $contexts, Command $command): array {
+        $event = new AlterConfigContextsEvent($contexts, $command);
+        $this->dispatcher->dispatch($event);
+        return $event->getContexts();
+    }
+
+    public function pushConfig(PolymerConfig $config): void {
+        $this->config->pushConfig($config);
+    }
+
+    public function popConfig(): ConfigInterface|null {
+        return $this->config->popConfig();
+    }
+}

--- a/src/Robo/Config/ConfigStack.php
+++ b/src/Robo/Config/ConfigStack.php
@@ -4,8 +4,8 @@ namespace DigitalPolygon\Polymer\Robo\Config;
 
 use Consolidation\Config\ConfigInterface;
 
-class ConfigStack implements ConfigStackInterface, ConfigInterface, \Countable {
-
+class ConfigStack implements ConfigStackInterface, ConfigInterface, \Countable
+{
     /**
      * @var ConfigInterface[]
      */

--- a/src/Robo/Config/ConfigStack.php
+++ b/src/Robo/Config/ConfigStack.php
@@ -11,47 +11,73 @@ class ConfigStack implements ConfigStackInterface, ConfigInterface, \Countable
      */
     protected array $stack;
 
-    public function has($key)
+    /**
+     * {@inheritdoc}
+     */
+    public function has($key): bool
     {
-        $this->getCurrentConfig()->has($key);
+        return $this->getCurrentConfig()->has($key);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function get($key, $defaultFallback = null)
     {
         return $this->getCurrentConfig()->get($key, $defaultFallback);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function set($key, $value)
     {
         $this->getCurrentConfig()->set($key, $value);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function import($data)
     {
-        $this->getCurrentConfig()->import($data);
+        return $this->getCurrentConfig()->import($data);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function export()
     {
         return $this->getCurrentConfig()->export();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasDefault($key)
     {
         return $this->getCurrentConfig()->hasDefault($key);
     }
 
-    public function getDefault($key, $defaultFallback = null)
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefault($key, $defaultFallback = null): mixed
     {
         return $this->getCurrentConfig()->getDefault($key, $defaultFallback);
     }
 
-    public function setDefault($key, $value)
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefault($key, $value): void
     {
         $this->getCurrentConfig()->setDefault($key, $value);
     }
 
-    public function pushConfig(ConfigInterface $config)
+    public function pushConfig(ConfigInterface $config): void
     {
         $this->stack[] = $config;
     }

--- a/src/Robo/Config/ConfigStack.php
+++ b/src/Robo/Config/ConfigStack.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Config;
+
+use Consolidation\Config\ConfigInterface;
+
+class ConfigStack implements ConfigStackInterface, ConfigInterface, \Countable {
+
+    /**
+     * @var ConfigInterface[]
+     */
+    protected array $stack;
+
+    public function has($key)
+    {
+        $this->getCurrentConfig()->has($key);
+    }
+
+    public function get($key, $defaultFallback = null)
+    {
+        return $this->getCurrentConfig()->get($key, $defaultFallback);
+    }
+
+    public function set($key, $value)
+    {
+        $this->getCurrentConfig()->set($key, $value);
+    }
+
+    public function import($data)
+    {
+        $this->getCurrentConfig()->import($data);
+    }
+
+    public function export()
+    {
+        return $this->getCurrentConfig()->export();
+    }
+
+    public function hasDefault($key)
+    {
+        return $this->getCurrentConfig()->hasDefault($key);
+    }
+
+    public function getDefault($key, $defaultFallback = null)
+    {
+        return $this->getCurrentConfig()->getDefault($key, $defaultFallback);
+    }
+
+    public function setDefault($key, $value)
+    {
+        $this->getCurrentConfig()->setDefault($key, $value);
+    }
+
+    public function pushConfig(ConfigInterface $config)
+    {
+        $this->stack[] = $config;
+    }
+
+    public function popConfig(): ?ConfigInterface
+    {
+        return array_pop($this->stack);
+    }
+
+    protected function getCurrentConfig(): ConfigInterface|false
+    {
+        return end($this->stack);
+    }
+
+    public function count(): int
+    {
+        return count($this->stack);
+    }
+}

--- a/src/Robo/Config/ConfigStackInterface.php
+++ b/src/Robo/Config/ConfigStackInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Config;
+
+use Consolidation\Config\ConfigInterface;
+
+interface ConfigStackInterface
+{
+    public function pushConfig(ConfigInterface $config);
+    public function popConfig(): ?ConfigInterface;
+}

--- a/src/Robo/Config/ConfigStackInterface.php
+++ b/src/Robo/Config/ConfigStackInterface.php
@@ -6,6 +6,6 @@ use Consolidation\Config\ConfigInterface;
 
 interface ConfigStackInterface
 {
-    public function pushConfig(ConfigInterface $config);
+    public function pushConfig(ConfigInterface $config): void;
     public function popConfig(): ?ConfigInterface;
 }

--- a/src/Robo/Config/PolymerConfig.php
+++ b/src/Robo/Config/PolymerConfig.php
@@ -84,5 +84,4 @@ class PolymerConfig extends RoboConfig
         $this->reprocess();
         return $self;
     }
-
 }

--- a/src/Robo/Config/PolymerConfig.php
+++ b/src/Robo/Config/PolymerConfig.php
@@ -6,7 +6,6 @@ use Consolidation\Config\Config;
 use Consolidation\Config\Config as ConsolidationConfig;
 use Consolidation\Config\ConfigInterface;
 use Consolidation\Config\Loader\YamlConfigLoader;
-use Consolidation\Config\Util\ConfigOverlay;
 use Robo\Config\Config as RoboConfig;
 
 /**
@@ -14,51 +13,25 @@ use Robo\Config\Config as RoboConfig;
  */
 class PolymerConfig extends RoboConfig
 {
-    /**
-     * DefaultConfig constructor.
-     *
-     * @param string $repo_root
-     *   The repository root of the project that depends on Polymer.
-     */
-    public function __construct($repo_root)
-    {
-        parent::__construct();
-        $this->setDefault('repo.root', $repo_root);
-        $this->setDefault('docroot', $repo_root . '/web');
-        $this->setDefault('polymer.root', $this->getPolymerRoot());
-        $this->setDefault('composer.bin', $repo_root . '/vendor/bin');
-        $this->setDefault('tmp.dir', sys_get_temp_dir());
-
-        $loader = new YamlConfigLoader();
-        $polymerBaseConfig = $loader->load($this->getPolymerRoot() . '/config/default.yml')->export();
-        $this->addContext('polymer', new ConsolidationConfig($polymerBaseConfig));
-    }
-
-    /**
-     * Gets the Polymer root directory, e.g., /vendor/digitalpolygon/polymer.
-     *
-     * @return string
-     *   THe filepath for the Polymer root.
-     *
-     * @throws \Exception
-     */
-    private function getPolymerRoot(): string
-    {
-        $possible_polymer_roots = [
-            dirname(dirname(dirname(dirname(__FILE__)))),
-            dirname(dirname(dirname(__FILE__))),
-        ];
-        foreach ($possible_polymer_roots as $polymer_root) {
-            if (basename($polymer_root) !== 'polymer') {
-                continue;
-            }
-            if (!file_exists("$polymer_root/src/Robo/Polymer.php")) {
-                continue;
-            }
-            return $polymer_root;
-        }
-        throw new \Exception('Could not find the Polymer root directory');
-    }
+//    /**
+//     * DefaultConfig constructor.
+//     *
+//     * @param string $repo_root
+//     *   The repository root of the project that depends on Polymer.
+//     */
+//    public function __construct($repo_root)
+//    {
+//        parent::__construct();
+//        $this->setDefault('repo.root', $repo_root);
+//        $this->setDefault('docroot', $repo_root . '/web');
+//        $this->setDefault('polymer.root', $this->getPolymerRoot());
+//        $this->setDefault('composer.bin', $repo_root . '/vendor/bin');
+//        $this->setDefault('tmp.dir', sys_get_temp_dir());
+//
+//        $loader = new YamlConfigLoader();
+//        $polymerBaseConfig = $loader->load($this->getPolymerRoot() . '/config/default.yml')->export();
+//        $this->addContext('polymer', new ConsolidationConfig($polymerBaseConfig));
+//    }
 
     /**
      * Reprocess all contexts in order to replace placeholders.
@@ -112,17 +85,4 @@ class PolymerConfig extends RoboConfig
         return $self;
     }
 
-//    /**
-//     * Set site.
-//     *
-//     * @param string $site
-//     *   Site name.
-//     */
-//    public function setSite($site): void
-//    {
-//        $this->set('site', $site);
-//        if (!$this->get('drush.uri') && $site != 'default') {
-//            $this->set('drush.uri', $site);
-//        }
-//    }
 }

--- a/src/Robo/ConsoleApplication.php
+++ b/src/Robo/ConsoleApplication.php
@@ -17,10 +17,7 @@ class ConsoleApplication extends Application
     public function __construct(string $name = 'UNKNOWN', string $version = 'UNKNOWN')
     {
         parent::__construct($name, $version);
-        $globalOptions = [
-            new InputOption('--environment', null, InputOption::VALUE_REQUIRED, 'Set the environment to load config from polymer/[env].polymer.yml file.', 'local'),
-        ];
-        $this->getDefinition()->addOptions($globalOptions);
+        $this->addGlobalOption(new InputOption('--environment', null, InputOption::VALUE_REQUIRED, 'Set the environment to load config from polymer/[env].polymer.yml file.', 'local'));
     }
 
     /**

--- a/src/Robo/Event/AlterConfigContextsEvent.php
+++ b/src/Robo/Event/AlterConfigContextsEvent.php
@@ -3,6 +3,7 @@
 namespace DigitalPolygon\Polymer\Robo\Event;
 
 use Consolidation\Config\ConfigInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class AlterConfigContextsEvent extends Event
@@ -10,9 +11,10 @@ class AlterConfigContextsEvent extends Event
     /**
      * @param array<string, ConfigInterface> $contexts
      */
-    public function __construct(protected array $contexts)
-    {
-    }
+    public function __construct(
+        protected array $contexts,
+        protected Command $command,
+    ) {}
 
     /**
      * @return array<string, ConfigInterface>
@@ -29,5 +31,12 @@ class AlterConfigContextsEvent extends Event
     public function setContexts(array $contexts): void
     {
         $this->contexts = $contexts;
+    }
+
+    /**
+     * @return Command
+     */
+    public function getCommand(): Command {
+        return clone $this->command;
     }
 }

--- a/src/Robo/Event/AlterConfigContextsEvent.php
+++ b/src/Robo/Event/AlterConfigContextsEvent.php
@@ -14,7 +14,8 @@ class AlterConfigContextsEvent extends Event
     public function __construct(
         protected array $contexts,
         protected Command $command,
-    ) {}
+    ) {
+    }
 
     /**
      * @return array<string, ConfigInterface>
@@ -36,7 +37,8 @@ class AlterConfigContextsEvent extends Event
     /**
      * @return Command
      */
-    public function getCommand(): Command {
+    public function getCommand(): Command
+    {
         return clone $this->command;
     }
 }

--- a/src/Robo/Event/CollectConfigContextsEvent.php
+++ b/src/Robo/Event/CollectConfigContextsEvent.php
@@ -2,31 +2,59 @@
 
 namespace DigitalPolygon\Polymer\Robo\Event;
 
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class CollectConfigContextsEvent extends Event
 {
     /**
-     * @var array<int, string>
+     * @var array<string, array>
      */
-    protected array $placeholderContexts = [];
+    protected array $contexts = [];
+
+    public function __construct(
+        protected Command $command ,
+        protected InputInterface $input,
+    ) {}
 
     /**
      * Add a single context.
      *
      * @param string $contextName
+     * @param array $data
+     *
      * @return void
      */
-    public function addPlaceholderContext(string $contextName): void
+    public function addContext(string $contextName, array $data): void
     {
-        $this->placeholderContexts[] = $contextName;
+        $this->contexts[$contextName] = $data;
+    }
+
+    public function addContexts(array $contexts): void
+    {
+        $this->contexts = array_merge($this->contexts, $contexts);
     }
 
     /**
-     * @return array<int, string>
+     * @return array<string, array>
      */
-    public function getPlaceholderContexts(): array
+    public function getContexts(): array
     {
-        return $this->placeholderContexts;
+        return $this->contexts;
+    }
+
+    /**
+     * @return Command
+     */
+    public function getCommand(): Command
+    {
+        // Return a clone of the command so that the caller cannot modify it.
+        return clone $this->command;
+    }
+
+    public function getInput(): InputInterface
+    {
+        return clone $this->input;
     }
 }

--- a/src/Robo/Event/CollectConfigContextsEvent.php
+++ b/src/Robo/Event/CollectConfigContextsEvent.php
@@ -14,9 +14,10 @@ class CollectConfigContextsEvent extends Event
     protected array $contexts = [];
 
     public function __construct(
-        protected Command $command ,
+        protected Command $command,
         protected InputInterface $input,
-    ) {}
+    ) {
+    }
 
     /**
      * Add a single context.

--- a/src/Robo/Extension/PolymerExtensionBase.php
+++ b/src/Robo/Extension/PolymerExtensionBase.php
@@ -27,7 +27,7 @@ abstract class PolymerExtensionBase implements PolymerExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function setDynamicConfiguration(DefinitionContainerInterface $container, ConfigInterface $config): void
+    public function setDynamicConfiguration(DefinitionContainerInterface $container, array &$config): void
     {
     }
 }

--- a/src/Robo/Extension/PolymerExtensionInterface.php
+++ b/src/Robo/Extension/PolymerExtensionInterface.php
@@ -61,9 +61,9 @@ interface PolymerExtensionInterface
      *
      * @param DefinitionContainerInterface $container
      *   The container instance.
-     * @param ConfigInterface $config
+     * @param array $config
      *   The default configuration context for this extension.
      * @return void
      */
-    public function setDynamicConfiguration(DefinitionContainerInterface $container, ConfigInterface $config): void;
+    public function setDynamicConfiguration(DefinitionContainerInterface $container, array &$config): void;
 }

--- a/src/Robo/Polymer.php
+++ b/src/Robo/Polymer.php
@@ -137,7 +137,8 @@ class Polymer implements ContainerAwareInterface, ConfigAwareInterface
         return $this;
     }
 
-    protected function setupBootContainer(): self {
+    protected function setupBootContainer(): self
+    {
         $this->bootContainer = new Container();
         $this->bootContainer->addShared('extensionDiscovery', ExtensionDiscovery::class)
             ->addArgument($this->classLoader);

--- a/src/Robo/Services/CommandInvoker.php
+++ b/src/Robo/Services/CommandInvoker.php
@@ -2,19 +2,15 @@
 
 namespace DigitalPolygon\Polymer\Robo\Services;
 
+use Consolidation\Config\ConfigInterface;
 use DigitalPolygon\Polymer\Robo\Common\ArrayManipulator;
-use DigitalPolygon\Polymer\Robo\Config\PolymerConfig;
+use DigitalPolygon\Polymer\Robo\Config\ConfigManager;
 use DigitalPolygon\Polymer\Robo\ConsoleApplication;
-use DigitalPolygon\Polymer\Robo\Event\PolymerEvents;
-use DigitalPolygon\Polymer\Robo\Event\PostInvokeCommandEvent;
-use DigitalPolygon\Polymer\Robo\Event\PreInvokeCommandEvent;
 use DigitalPolygon\Polymer\Robo\Exceptions\PolymerException;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
-use Robo\Common\IO;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -37,10 +33,11 @@ class CommandInvoker implements CommandInvokerInterface, ContainerAwareInterface
     public function __construct(
         protected EventDispatcherInterface $eventDispatcher,
         protected ConsoleApplication $application,
-        protected PolymerConfig $config,
+        protected ConfigInterface $config,
         protected InputInterface $input,
         protected OutputInterface $output,
         protected LoggerInterface $logger,
+        protected ConfigManager $configManager,
     ) {
     }
 
@@ -59,9 +56,8 @@ class CommandInvoker implements CommandInvokerInterface, ContainerAwareInterface
      */
     public function invokeCommand(InputInterface $parentInput, string $commandName, array $args = []): void
     {
-        $this->invokeDepth++;
-
         if (!$this->isCommandDisabled($commandName)) {
+            $this->invokeDepth++;
             $command = $this->application->find($commandName);
 
             // Build a new input object that inherits options from parent command.
@@ -82,7 +78,7 @@ class CommandInvoker implements CommandInvokerInterface, ContainerAwareInterface
 
 //            $preRunOptions = $this->input->getOptions();
 
-            $preInvokeEvent = new PreInvokeCommandEvent($command, $parentInput, $input, $this->invokeDepth);
+//            $preInvokeEvent = new PreInvokeCommandEvent($command, $parentInput, $input, $this->invokeDepth);
 //            $this->eventDispatcher->dispatch($preInvokeEvent, PolymerEvents::PRE_INVOKE_COMMAND);
 
             $exit_code = $this->application->runCommand($command, $input, $this->output);
@@ -94,10 +90,11 @@ class CommandInvoker implements CommandInvokerInterface, ContainerAwareInterface
 
 //            $postInvokeEvent = new PostInvokeCommandEvent($command, $parentInput, $input, $this->invokeDepth);
 //            $this->eventDispatcher->dispatch($postInvokeEvent, PolymerEvents::POST_INVOKE_COMMAND);
-            $this->config->reprocess();
+//            $this->config->reprocess();
 
 //            $postRunOptions = $this->input->getOptions();
 
+            $this->configManager->popConfig();
             $this->invokeDepth--;
 
             // The application will catch any exceptions thrown in the executed

--- a/src/Robo/Services/CommandInvoker.php
+++ b/src/Robo/Services/CommandInvoker.php
@@ -186,6 +186,7 @@ class CommandInvoker implements CommandInvokerInterface, ContainerAwareInterface
      */
     protected function getDisabledCommands(): array
     {
+        // @phpstan-ignore argument.type
         $disabled_commands_config = $this->config->get('disable-targets', []);
         if ($disabled_commands_config) {
             $disabled_commands = ArrayManipulator::flattenMultidimensionalArray($disabled_commands_config, ':');

--- a/src/Robo/Services/EventSubscriber/ConfigContextProvider.php
+++ b/src/Robo/Services/EventSubscriber/ConfigContextProvider.php
@@ -83,6 +83,11 @@ class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareI
         return $extensionConfig;
     }
 
+    /**
+     * @param InputInterface $input
+     *
+     * @return array<string, array>
+     */
     public function getProjectConfig(InputInterface $input): array
     {
         $projectConfig = [];

--- a/src/Robo/Services/EventSubscriber/ConfigContextProvider.php
+++ b/src/Robo/Services/EventSubscriber/ConfigContextProvider.php
@@ -10,14 +10,15 @@ use League\Container\ContainerAwareTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareInterface {
-
+class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareInterface
+{
     use ContainerAwareTrait;
 
     public function __construct(
         protected string $repoRoot,
         protected ExtensionDiscovery $extensionDiscovery,
-    ) {}
+    ) {
+    }
 
     public function collectContexts(CollectConfigContextsEvent $event): void
     {
@@ -34,7 +35,8 @@ class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareI
         $event->addContexts($contexts);
     }
 
-    public function getSystemConfig(): array {
+    public function getSystemConfig(): array
+    {
         $filesystemLocations = [
             'repo.root' => $this->repoRoot,
             'docroot' => $this->repoRoot . '/web',
@@ -50,7 +52,8 @@ class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareI
         });
     }
 
-    public function getPolymerApplicationConfig(): array|null {
+    public function getPolymerApplicationConfig(): array|null
+    {
         $polymerDefaultFilePath = $this->getPolymerRoot() . '/config/default.yml';
         if (file_exists($polymerDefaultFilePath)) {
             $loader = new YamlConfigLoader();
@@ -59,7 +62,8 @@ class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareI
         return null;
     }
 
-    public function getExtensionConfig(): array {
+    public function getExtensionConfig(): array
+    {
         $extensionConfig = [];
         $extensions = $this->extensionDiscovery->getExtensions();
         foreach ($extensions as $extensionId => $extensionInfo) {
@@ -79,7 +83,8 @@ class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareI
         return $extensionConfig;
     }
 
-    public function getProjectConfig(InputInterface $input): array {
+    public function getProjectConfig(InputInterface $input): array
+    {
         $projectConfig = [];
         $potentialFiles['project'] = $this->repoRoot . '/polymer/polymer.yml';
         $environment = $input->getOption('environment');

--- a/src/Robo/Services/EventSubscriber/ConfigContextProvider.php
+++ b/src/Robo/Services/EventSubscriber/ConfigContextProvider.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Services\EventSubscriber;
+
+use Consolidation\Config\Loader\YamlConfigLoader;
+use DigitalPolygon\Polymer\Robo\Discovery\ExtensionDiscovery;
+use DigitalPolygon\Polymer\Robo\Event\CollectConfigContextsEvent;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ConfigContextProvider implements EventSubscriberInterface, ContainerAwareInterface {
+
+    use ContainerAwareTrait;
+
+    public function __construct(
+        protected string $repoRoot,
+        protected ExtensionDiscovery $extensionDiscovery,
+    ) {}
+
+    public function collectContexts(CollectConfigContextsEvent $event): void
+    {
+        $contexts = [];
+        $contexts['system'] = $this->getSystemConfig();
+        if (!empty($polymerConfig = $this->getPolymerApplicationConfig())) {
+            $contexts['polymer'] = $polymerConfig;
+        }
+        $contexts = array_merge(
+            $contexts,
+            $this->getExtensionConfig(),
+            $this->getProjectConfig($event->getInput()),
+        );
+        $event->addContexts($contexts);
+    }
+
+    public function getSystemConfig(): array {
+        $filesystemLocations = [
+            'repo.root' => $this->repoRoot,
+            'docroot' => $this->repoRoot . '/web',
+            'polymer.root' => $this->getPolymerRoot(),
+            'composer.bin' => $this->repoRoot . '/vendor/bin',
+            'tmp.dir' => sys_get_temp_dir(),
+        ];
+        return array_filter($filesystemLocations, function ($path) {
+            if (!file_exists($path)) {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    public function getPolymerApplicationConfig(): array|null {
+        $polymerDefaultFilePath = $this->getPolymerRoot() . '/config/default.yml';
+        if (file_exists($polymerDefaultFilePath)) {
+            $loader = new YamlConfigLoader();
+            return $loader->load($polymerDefaultFilePath)->export();
+        }
+        return null;
+    }
+
+    public function getExtensionConfig(): array {
+        $extensionConfig = [];
+        $extensions = $this->extensionDiscovery->getExtensions();
+        foreach ($extensions as $extensionId => $extensionInfo) {
+            $config = [];
+            if (($configFile = $extensionInfo->getConfigFile()) && file_exists($configFile)) {
+                $loader = new YamlConfigLoader();
+                $config = $loader->load($configFile)->export();
+            }
+            $config['extension.' . $extensionId] = [
+                'root' => $extensionInfo->getRoot(),
+            ];
+            $extensionInfo
+                ->getExtension()
+                ->setDynamicConfiguration($this->getContainer(), $config);
+            $extensionConfig[$extensionId] = $config;
+        }
+        return $extensionConfig;
+    }
+
+    public function getProjectConfig(InputInterface $input): array {
+        $projectConfig = [];
+        $potentialFiles['project'] = $this->repoRoot . '/polymer/polymer.yml';
+        $environment = $input->getOption('environment');
+        if (is_string($environment)) {
+            $potentialFiles['project_environment'] = $this->repoRoot . '/polymer/' . $environment . 'polymer.yml';
+        }
+        $potentialFiles = array_filter($potentialFiles, function ($file) {
+            return file_exists($file);
+        });
+        foreach ($potentialFiles as $configId => $file) {
+            $loader = new YamlConfigLoader();
+            $projectConfig[$configId] = $loader->load($file)->export();
+        }
+        return $projectConfig;
+    }
+
+    private function getPolymerRoot(): string
+    {
+        $possible_polymer_roots = [
+            dirname(dirname(dirname(dirname(dirname(__FILE__))))),
+            dirname(dirname(dirname(dirname(__FILE__)))),
+        ];
+        foreach ($possible_polymer_roots as $polymer_root) {
+            if (basename($polymer_root) !== 'polymer') {
+                continue;
+            }
+            if (!file_exists("$polymer_root/src/Robo/Polymer.php")) {
+                continue;
+            }
+            return $polymer_root;
+        }
+        throw new \Exception('Could not find the Polymer root directory');
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            CollectConfigContextsEvent::class => ['collectContexts', 9999],
+        ];
+    }
+}

--- a/src/Robo/Services/EventSubscriber/ConfigInjector.php
+++ b/src/Robo/Services/EventSubscriber/ConfigInjector.php
@@ -57,10 +57,11 @@ class ConfigInjector extends GlobalOptionsEventListener implements EventSubscrib
 
     public static function getSubscribedEvents(): array
     {
-        return [
-            ConsoleEvents::COMMAND => [
-                ['injectEnvironmentConfig', 50],
-            ],
-        ];
+        return [];
+//        return [
+//            ConsoleEvents::COMMAND => [
+//                ['injectEnvironmentConfig', 50],
+//            ],
+//        ];
     }
 }

--- a/src/Robo/Services/EventSubscriber/LoadConfiguration.php
+++ b/src/Robo/Services/EventSubscriber/LoadConfiguration.php
@@ -37,7 +37,9 @@ class LoadConfiguration implements EventSubscriberInterface, ConfigAwareInterfac
     {
         // Carry forward values expected to be there, see Robo::configureContainer around line 294.
         $freshConfig = new PolymerConfig();
+        // @phpstan-ignore classConstant.deprecatedClass,classConstant.deprecatedClass
         $freshConfig->set(\Robo\Config::DECORATED, $this->getConfig()->get(\Robo\Config::DECORATED));
+        // @phpstan-ignore classConstant.deprecatedClass,classConstant.deprecatedClass
         $freshConfig->set(\Robo\Config::INTERACTIVE, $this->getConfig()->get(\Robo\Config::INTERACTIVE));
         return $freshConfig;
     }

--- a/src/Robo/Services/EventSubscriber/LoadConfiguration.php
+++ b/src/Robo/Services/EventSubscriber/LoadConfiguration.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Services\EventSubscriber;
+
+use Consolidation\Config\Config;
+use DigitalPolygon\Polymer\Robo\Config\ConfigManager;
+use DigitalPolygon\Polymer\Robo\Config\ConfigStack;
+use DigitalPolygon\Polymer\Robo\Config\PolymerConfig;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Robo\Common\ConfigAwareTrait;
+use Robo\Contract\ConfigAwareInterface;
+
+class LoadConfiguration implements EventSubscriberInterface, ConfigAwareInterface, ContainerAwareInterface {
+    use ConfigAwareTrait;
+    use ContainerAwareTrait;
+
+    public function loadConfiguration(ConsoleCommandEvent $event): void {
+        /** @var ConfigManager $configManager */
+        $configManager = $this->getContainer()->get('configManager');
+        $contextData = $configManager->collectContextData($event->getCommand(), $event->getInput());
+        $contextData = $configManager->alterContextData($contextData, $event->getCommand());
+        $polymerConfig = $this->getFreshConfig();
+        foreach ($contextData as $contextId => $data) {
+            $contextConfig = new Config($data);
+            $polymerConfig->addContext($contextId, $contextConfig);
+        }
+        $configManager->pushConfig($polymerConfig);
+    }
+
+    public function getFreshConfig(): PolymerConfig {
+        // Carry forward values expected to be there, see Robo::configureContainer around line 294.
+        $freshConfig = new PolymerConfig();
+        $freshConfig->set(\Robo\Config::DECORATED, $this->getConfig()->get(\Robo\Config::DECORATED));
+        $freshConfig->set(\Robo\Config::INTERACTIVE, $this->getConfig()->get(\Robo\Config::INTERACTIVE));
+        return $freshConfig;
+    }
+
+    public static function getSubscribedEvents(): array {
+        return [
+            ConsoleEvents::COMMAND => ['loadConfiguration', 50],
+        ];
+    }
+}

--- a/src/Robo/Services/EventSubscriber/LoadConfiguration.php
+++ b/src/Robo/Services/EventSubscriber/LoadConfiguration.php
@@ -37,9 +37,7 @@ class LoadConfiguration implements EventSubscriberInterface, ConfigAwareInterfac
     {
         // Carry forward values expected to be there, see Robo::configureContainer around line 294.
         $freshConfig = new PolymerConfig();
-        // @phpstan-ignore classConstant.deprecatedClass,classConstant.deprecatedClass
         $freshConfig->set(\Robo\Config::DECORATED, $this->getConfig()->get(\Robo\Config::DECORATED));
-        // @phpstan-ignore classConstant.deprecatedClass,classConstant.deprecatedClass
         $freshConfig->set(\Robo\Config::INTERACTIVE, $this->getConfig()->get(\Robo\Config::INTERACTIVE));
         return $freshConfig;
     }

--- a/src/Robo/Services/EventSubscriber/LoadConfiguration.php
+++ b/src/Robo/Services/EventSubscriber/LoadConfiguration.php
@@ -14,11 +14,13 @@ use League\Container\ContainerAwareTrait;
 use Robo\Common\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 
-class LoadConfiguration implements EventSubscriberInterface, ConfigAwareInterface, ContainerAwareInterface {
+class LoadConfiguration implements EventSubscriberInterface, ConfigAwareInterface, ContainerAwareInterface
+{
     use ConfigAwareTrait;
     use ContainerAwareTrait;
 
-    public function loadConfiguration(ConsoleCommandEvent $event): void {
+    public function loadConfiguration(ConsoleCommandEvent $event): void
+    {
         /** @var ConfigManager $configManager */
         $configManager = $this->getContainer()->get('configManager');
         $contextData = $configManager->collectContextData($event->getCommand(), $event->getInput());
@@ -31,7 +33,8 @@ class LoadConfiguration implements EventSubscriberInterface, ConfigAwareInterfac
         $configManager->pushConfig($polymerConfig);
     }
 
-    public function getFreshConfig(): PolymerConfig {
+    public function getFreshConfig(): PolymerConfig
+    {
         // Carry forward values expected to be there, see Robo::configureContainer around line 294.
         $freshConfig = new PolymerConfig();
         $freshConfig->set(\Robo\Config::DECORATED, $this->getConfig()->get(\Robo\Config::DECORATED));
@@ -39,7 +42,8 @@ class LoadConfiguration implements EventSubscriberInterface, ConfigAwareInterfac
         return $freshConfig;
     }
 
-    public static function getSubscribedEvents(): array {
+    public static function getSubscribedEvents(): array
+    {
         return [
             ConsoleEvents::COMMAND => ['loadConfiguration', 50],
         ];


### PR DESCRIPTION
# Changes

- Refactors the configuration loading mechanism such that configuration is unique to each command execution invocation. For example, the initial configuration is loaded for the issued command, but if the `commandInvoker` service is used to invoke a command, then the invoked command will have an independent configuration available to it.
    - When a command is invoked by `commandInvoker`, the configuration is restored to what it was after the invoked command has finished running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic configuration management system that streamlines context collection and modification.
  - Added new services to facilitate on-the-fly configuration loading and integration with command events.

- **Refactor**
  - Simplified the global command option setup and removed redundant configuration initialization.
  - Updated event subscription and dependency injection mechanisms for a more modular service architecture.

- **Chores**
  - Enhanced overall service management and dependency organization for improved maintainability.
  - Added a new error identifier to the PHPStan configuration for better error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->