### PR TITLE
PWT-112: Allow Robo 5.x to unblock downstream dependencies requiring Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": ">=8.1",
     "composer-plugin-api": "^2.0",
     "composer-runtime-api": "^2.0",
-    "consolidation/robo": "^4"
+    "consolidation/robo": "^4 || ^5"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
@@ -26,10 +26,6 @@
     }
   },
   "config": {
-    "php": "8",
-    "platform": {
-      "php": "8.1"
-    },
     "sort-packages": true,
     "allow-plugins": {
       "phpstan/extension-installer": true,


### PR DESCRIPTION
# Changes

- Allow consolidation/robo:^5 to permit projects to use packages that requires Symfony 7.
- Remove PHP platform constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced dependency support to allow for broader package version compatibility.
	- Adjusted internal configuration to remove strict PHP version constraints for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->