### PR TITLE
Plugin Manager and Template Refactor

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,8 +12,6 @@ parameters:
             message: "#^Parameter \\#2 \\$default of method Consolidation\\\\Config\\\\Util\\\\ConfigOverlay\\:\\:get\\(\\) expects string\\|null, array given\\.$#"
         -
             identifier: missingType.iterableValue
-        -
-            identifier: new.static
 #services:
 #    -
 #        class: DigitalPolygon\PolymerTest\PHPStan\CollectionBuilderReflectionExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,8 @@ parameters:
             message: "#^Parameter \\#2 \\$default of method Consolidation\\\\Config\\\\Util\\\\ConfigOverlay\\:\\:get\\(\\) expects string\\|null, array given\\.$#"
         -
             identifier: missingType.iterableValue
+        -
+            identifier: new.static
 #services:
 #    -
 #        class: DigitalPolygon\PolymerTest\PHPStan\CollectionBuilderReflectionExtension

--- a/src/Robo/Commands/Template/TemplateCommand.php
+++ b/src/Robo/Commands/Template/TemplateCommand.php
@@ -16,6 +16,7 @@ use DigitalPolygon\Polymer\Robo\Exceptions\PolymerException;
 use DigitalPolygon\Polymer\Robo\Services\Template\Generator;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 use DigitalPolygon\Polymer\Robo\Template\TemplateInterface;
+use DigitalPolygon\Polymer\Robo\Template\TemplatePluginManager;
 use DigitalPolygon\Polymer\Robo\Utility\CommandHelper;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -43,9 +44,12 @@ final class TemplateCommand extends TaskBase
     #[HookSelector(name: 'validateTemplateExistence')]
     public function generateTemplate(ConsoleIO $io, string $template, bool $force = true): int
     {
+        /** @var TemplatePluginManager $templatePluginManager */
+        $templatePluginManager = $this->getContainer()->get('templatePluginManager');
         /** @var Generator $generator */
         $generator = $this->getContainer()->get('templateGenerator');
-        $templateInstance = $this->getContainer()->get(TemplateInterface::SERVICE_PREFIX . $template);
+        /** @var TemplateInterface $templateInstance */
+        $templateInstance = $templatePluginManager->getDefinition($template);
         $generator->generate($templateInstance, $force);
         return 0;
     }
@@ -64,7 +68,9 @@ final class TemplateCommand extends TaskBase
     #[HookSelector(name: 'validateTemplateExistence')]
     public function generateCollection(ConsoleIO $io, string $collection): int
     {
-        $templates = $this->getContainer()->get('plugin.templates.collections.' . $collection);
+        /** @var TemplatePluginManager $templatePluginManager */
+        $templatePluginManager = $this->getContainer()->get('templatePluginManager');
+        $templates = $templatePluginManager->getTemplatesFromCollection($collection);
         /** @var Generator $generator */
         $generator = $this->getContainer()->get('templateGenerator');
         foreach ($templates as $template) {
@@ -106,8 +112,10 @@ final class TemplateCommand extends TaskBase
     #[HookSelector(name: 'validateTemplateExistence')]
     public function listTemplates(ConsoleIO $io, string $collection = 'all', array $options = []): RowsOfFields
     {
+        /** @var TemplatePluginManager $templatePluginManager */
+        $templatePluginManager = $this->getContainer()->get('templatePluginManager');
         /** @var TemplateInterface[] $templates */
-        $templates = $this->getContainer()->get('plugin.templates.collections.' . $collection);
+        $templates = $templatePluginManager->getTemplatesFromCollection($collection);
         $data = [];
         foreach ($templates as $template) {
             $tokenMap = array_combine(
@@ -137,14 +145,16 @@ final class TemplateCommand extends TaskBase
     #[Hook(type: HookManager::ARGUMENT_VALIDATOR, selector: 'validateTemplateExistence')]
     public function validateTemplateOrCollectionExistence(CommandData $commandData): void
     {
+        /** @var TemplatePluginManager $pluginManager */
+        $pluginManager = $this->getContainer()->get('templatePluginManager');
         // If an option or argument named template or collection exists, validate that they
         // exist before proceeding to command execution.
         $template = CommandHelper::getArgumentOrOptionValue($commandData->input(), 'template');
         $collection = CommandHelper::getArgumentOrOptionValue($commandData->input(), 'collection');
-        if (!empty($template) && !$this->getContainer()->has(TemplateInterface::SERVICE_PREFIX . $template)) {
+        if (!empty($template) && !$pluginManager->hasDefinition($template)) {
             throw new PolymerException('Template not found: ' . $template);
         }
-        if (!empty($collection) && !$this->getContainer()->has('plugin.templates.collections.' . $collection)) {
+        if (!empty($collection) && !$pluginManager->hasCollection($collection)) {
             throw new PolymerException('Collection not found: ' . $collection);
         }
     }
@@ -160,8 +170,10 @@ final class TemplateCommand extends TaskBase
     {
         $data = [];
         $collections = [];
+        /** @var TemplatePluginManager $templateManager */
+        $templateManager = $this->getContainer()->get('templatePluginManager');
         /** @var TemplateInterface[] $allTemplates */
-        $allTemplates = $this->getContainer()->get('plugin.templates.collections.all');
+        $allTemplates = $templateManager->getTemplatesFromCollection('all');
         foreach ($allTemplates as $template) {
             $collections = array_merge($collections, $template->collections());
         }

--- a/src/Robo/Contract/ClassLoaderAwareInterface.php
+++ b/src/Robo/Contract/ClassLoaderAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Contract;
+
+use Composer\Autoload\ClassLoader;
+
+interface ClassLoaderAwareInterface
+{
+    public function setClassLoader(ClassLoader $classLoader): void;
+}

--- a/src/Robo/Discovery/Plugin/PluginBase.php
+++ b/src/Robo/Discovery/Plugin/PluginBase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Discovery\Plugin;
+
+use League\Container\Container;
+
+abstract class PluginBase implements PluginInterface
+{
+    public static function create(Container $container): self
+    {
+        return new static();
+    }
+}

--- a/src/Robo/Discovery/Plugin/PluginBase.php
+++ b/src/Robo/Discovery/Plugin/PluginBase.php
@@ -2,12 +2,9 @@
 
 namespace DigitalPolygon\Polymer\Robo\Discovery\Plugin;
 
-use League\Container\Container;
+use League\Container\ContainerAwareInterface;
+use Robo\Contract\ConfigAwareInterface;
 
-abstract class PluginBase implements PluginInterface
+abstract class PluginBase implements PluginInterface, ConfigAwareInterface, ContainerAwareInterface
 {
-    public static function create(Container $container): self
-    {
-        return new static();
-    }
 }

--- a/src/Robo/Discovery/Plugin/PluginInterface.php
+++ b/src/Robo/Discovery/Plugin/PluginInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Discovery\Plugin;
+
+use League\Container\Container;
+
+interface PluginInterface
+{
+    public static function id(): string;
+    public static function create(Container $container): self;
+}

--- a/src/Robo/Discovery/Plugin/PluginInterface.php
+++ b/src/Robo/Discovery/Plugin/PluginInterface.php
@@ -7,5 +7,4 @@ use League\Container\Container;
 interface PluginInterface
 {
     public static function id(): string;
-    public static function create(Container $container): self;
 }

--- a/src/Robo/Discovery/Plugin/PluginManagerBase.php
+++ b/src/Robo/Discovery/Plugin/PluginManagerBase.php
@@ -26,7 +26,7 @@ abstract class PluginManagerBase implements PluginManagerInterface, ContainerAwa
     {
         $this->discovery = new RelativeNamespaceDiscovery($this->classLoader);
         $this->discovery->setRelativeNamespace($this->relativeNamespace);
-        if (is_subclass_of($this->pluginInterface, PluginInterface::class)) {
+        if (!is_subclass_of($this->pluginInterface, PluginInterface::class)) {
             throw new \RuntimeException(sprintf("Plugin interface %s must implement %s", $this->pluginInterface, PluginInterface::class));
         }
     }

--- a/src/Robo/Discovery/Plugin/PluginManagerBase.php
+++ b/src/Robo/Discovery/Plugin/PluginManagerBase.php
@@ -4,9 +4,14 @@ namespace DigitalPolygon\Polymer\Robo\Discovery\Plugin;
 
 use DigitalPolygon\Polymer\Robo\Contract\ClassLoaderAwareInterface;
 use DigitalPolygon\Polymer\Robo\Services\ClassLoaderAwareTrait;
+use League\Container\Argument\ResolvableArgument;
+use League\Container\Container;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
+use League\Container\Definition\DefinitionAggregate;
+use League\Container\Definition\DefinitionAggregateInterface;
 use Robo\ClassDiscovery\RelativeNamespaceDiscovery;
+use Robo\Contract\ConfigAwareInterface;
 
 abstract class PluginManagerBase implements PluginManagerInterface, ContainerAwareInterface, ClassLoaderAwareInterface
 {
@@ -14,45 +19,68 @@ abstract class PluginManagerBase implements PluginManagerInterface, ContainerAwa
     use ClassLoaderAwareTrait;
 
     protected RelativeNamespaceDiscovery $discovery;
-    protected string $pluginPrefix;
-    /**
-     * @var PluginInterface[]
-     */
-    protected array $definitions = [];
+
     protected string $relativeNamespace;
     protected string $pluginInterface;
+    protected Container $definitionContainer;
 
     public function configureDiscovery(): void
     {
-        $this->discovery = new RelativeNamespaceDiscovery($this->classLoader);
-        $this->discovery->setRelativeNamespace($this->relativeNamespace);
+        $this->setDiscoveryData();
+        if (empty($this->relativeNamespace) || empty($this->pluginInterface)) {
+            throw new \RuntimeException(sprintf("Discovery data not set for plugin manager '%s'. Make sure to set the relative namespace and plugin interface.", self::class));
+        }
         if (!is_subclass_of($this->pluginInterface, PluginInterface::class)) {
             throw new \RuntimeException(sprintf("Plugin interface %s must implement %s", $this->pluginInterface, PluginInterface::class));
         }
+
+        $this->configureContainer();
+
+        $this->discovery = new RelativeNamespaceDiscovery($this->classLoader);
+        $this->discovery->setRelativeNamespace($this->relativeNamespace);
+
+        $classes = array_filter($this->discovery->getClasses(), fn ($class) => is_subclass_of($class, $this->pluginInterface));
+        foreach ($classes as $class) {
+            $id = $class::id();
+            $this->definitionContainer->add($id, $class)
+               ->addTag('plugin');
+        }
+    }
+
+  /**
+   * Configure the definition container.
+   *
+   * Plugin manager classes can extend this to add their own inflectors
+   * as necessary.
+   *
+   * @return void
+   */
+    protected function configureContainer(): void
+    {
+        // Definition container needs to have its own inflectors setup.
+        $this->definitionContainer = new Container();
+        $this->definitionContainer->delegate($this->getContainer());
+        $this->definitionContainer->inflector(ConfigAwareInterface::class)
+            ->invokeMethod('setConfig', [new ResolvableArgument('config')]);
+        $this->definitionContainer->inflector(ContainerAwareInterface::class)
+            ->invokeMethod('setContainer', [new ResolvableArgument('container')]);
     }
 
     public function getDefinitions(): array
     {
-        if (!$this->definitions) {
-            $classes = array_filter($this->discovery->getClasses(), fn ($class) => is_subclass_of($class, $this->pluginInterface));
-            foreach ($classes as $class) {
-                $id = $class::id();
-                $this->definitions[$id] = $class::create($this->getContainer());
-            }
-        }
-        return $this->definitions;
+        return $this->definitionContainer->get('plugin');
     }
 
     public function getDefinition(string $id): PluginInterface
     {
-        if (isset($this->definitions[$id])) {
-            return $this->definitions[$id];
+        if ($this->definitionContainer->has($id)) {
+            return $this->definitionContainer->get($id);
         }
         throw new \RuntimeException(sprintf("Definition for plugin %s does not exist.", $id));
     }
 
     public function hasDefinition(string $id): bool
     {
-        return isset($this->definitions[$id]);
+        return $this->definitionContainer->has($id);
     }
 }

--- a/src/Robo/Discovery/Plugin/PluginManagerBase.php
+++ b/src/Robo/Discovery/Plugin/PluginManagerBase.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Discovery\Plugin;
+
+use DigitalPolygon\Polymer\Robo\Contract\ClassLoaderAwareInterface;
+use DigitalPolygon\Polymer\Robo\Services\ClassLoaderAwareTrait;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Robo\ClassDiscovery\RelativeNamespaceDiscovery;
+
+abstract class PluginManagerBase implements PluginManagerInterface, ContainerAwareInterface, ClassLoaderAwareInterface
+{
+    use ContainerAwareTrait;
+    use ClassLoaderAwareTrait;
+
+    protected RelativeNamespaceDiscovery $discovery;
+    protected string $pluginPrefix;
+    /**
+     * @var PluginInterface[]
+     */
+    protected array $definitions = [];
+    protected string $relativeNamespace;
+    protected string $pluginInterface;
+
+    public function configureDiscovery(): void
+    {
+        $this->discovery = new RelativeNamespaceDiscovery($this->classLoader);
+        $this->discovery->setRelativeNamespace($this->relativeNamespace);
+        if (is_subclass_of($this->pluginInterface, PluginInterface::class)) {
+            throw new \RuntimeException(sprintf("Plugin interface %s must implement %s", $this->pluginInterface, PluginInterface::class));
+        }
+    }
+
+    public function getDefinitions(): array
+    {
+        if (!$this->definitions) {
+            $classes = array_filter($this->discovery->getClasses(), fn ($class) => is_subclass_of($class, $this->pluginInterface));
+            foreach ($classes as $class) {
+                $id = $class::id();
+                $this->definitions[$id] = $class::create($this->getContainer());
+            }
+        }
+        return $this->definitions;
+    }
+
+    public function getDefinition(string $id): PluginInterface
+    {
+        if (isset($this->definitions[$id])) {
+            return $this->definitions[$id];
+        }
+        throw new \RuntimeException(sprintf("Definition for plugin %s does not exist.", $id));
+    }
+
+    public function hasDefinition(string $id): bool
+    {
+        return isset($this->definitions[$id]);
+    }
+}

--- a/src/Robo/Discovery/Plugin/PluginManagerInterface.php
+++ b/src/Robo/Discovery/Plugin/PluginManagerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Discovery\Plugin;
+
+interface PluginManagerInterface
+{
+    public function setDiscoveryData(): void;
+    public function configureDiscovery(): void;
+    public function getDefinition(string $id): PluginInterface;
+    public function getDefinitions(): array;
+    public function hasDefinition(string $id): bool;
+}

--- a/src/Robo/Polymer.php
+++ b/src/Robo/Polymer.php
@@ -213,7 +213,6 @@ class Polymer implements ContainerAwareInterface, ConfigAwareInterface
             ->invokeMethod('setClassLoader', [new ResolvableArgument('classLoader')]);
         $container->inflector(PluginManagerInterface::class)
             ->invokeMethods([
-                'setDiscoveryData' => [],
                 'configureDiscovery' => [],
                 'getDefinitions' => [],
             ]);

--- a/src/Robo/Polymer.php
+++ b/src/Robo/Polymer.php
@@ -4,6 +4,8 @@ namespace DigitalPolygon\Polymer\Robo;
 
 use Composer\Autoload\ClassLoader;
 use Composer\InstalledVersions;
+use DigitalPolygon\Polymer\Robo\Contract\ClassLoaderAwareInterface;
+use DigitalPolygon\Polymer\Robo\Discovery\Plugin\PluginManagerInterface;
 use DigitalPolygon\Polymer\Robo\Services\TaskableServiceInterface;
 use DigitalPolygon\Polymer\Robo\Config\ConfigManager;
 use DigitalPolygon\Polymer\Robo\Config\ConfigStack;
@@ -20,6 +22,7 @@ use DigitalPolygon\Polymer\Robo\Services\EventSubscriber\ConfigInjector;
 use DigitalPolygon\Polymer\Robo\Services\EventSubscriber\LoadConfiguration;
 use DigitalPolygon\Polymer\Robo\Services\EventSubscriber\SetGlobalOptionsPostInvoke;
 use DigitalPolygon\Polymer\Robo\Services\Template\Generator;
+use DigitalPolygon\Polymer\Robo\Template\TemplatePluginManager;
 use League\Container\Argument\LiteralArgument;
 use League\Container\Argument\ResolvableArgument;
 use League\Container\Container;
@@ -199,12 +202,21 @@ class Polymer implements ContainerAwareInterface, ConfigAwareInterface
             ->addMethodCall('addSubscriber', [new ResolvableArgument('polymerConfigContextProvider')]);
 
         $container->addShared('templateGenerator', Generator::class);
+        $container->addShared('templatePluginManager', TemplatePluginManager::class);
 
         // Inflectors.
         $container->inflector(CommandInvokerAwareInterface::class)
             ->invokeMethod('setCommandInvoker', [new ResolvableArgument('commandInvoker')]);
         $container->inflector(TaskableServiceInterface::class)
             ->invokeMethod('createCollectionBuilder', []);
+        $container->inflector(ClassLoaderAwareInterface::class)
+            ->invokeMethod('setClassLoader', [new ResolvableArgument('classLoader')]);
+        $container->inflector(PluginManagerInterface::class)
+            ->invokeMethods([
+                'setDiscoveryData' => [],
+                'configureDiscovery' => [],
+                'getDefinitions' => [],
+            ]);
 
         // Service providers.
         $serviceProviders = $this->collectServiceProviders();

--- a/src/Robo/Services/ClassLoaderAwareTrait.php
+++ b/src/Robo/Services/ClassLoaderAwareTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Services;
+
+use Composer\Autoload\ClassLoader;
+
+trait ClassLoaderAwareTrait
+{
+    protected ClassLoader $classLoader;
+    public function setClassLoader(ClassLoader $classLoader): void
+    {
+        $this->classLoader = $classLoader;
+    }
+}

--- a/src/Robo/Template/Template.php
+++ b/src/Robo/Template/Template.php
@@ -2,15 +2,27 @@
 
 namespace DigitalPolygon\Polymer\Robo\Template;
 
+use Consolidation\Config\ConfigInterface;
 use DigitalPolygon\Polymer\Robo\Config\ConfigAwareTrait;
-use League\Container\ContainerAwareInterface;
-use League\Container\ContainerAwareTrait;
+use DigitalPolygon\Polymer\Robo\Discovery\Plugin\PluginBase;
+use League\Container\Container;
 use Robo\Contract\ConfigAwareInterface;
 
-abstract class Template implements TemplateInterface, ContainerAwareInterface, ConfigAwareInterface
+abstract class Template extends PluginBase implements TemplateInterface, ConfigAwareInterface
 {
-    use ContainerAwareTrait;
     use ConfigAwareTrait;
+
+    public function __construct(ConfigInterface $config = null)
+    {
+        if ($config) {
+            $this->setConfig($config);
+        }
+    }
+
+    public static function create(Container $container): self
+    {
+        return new static($container->get('config'));
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Robo/Template/Template.php
+++ b/src/Robo/Template/Template.php
@@ -2,27 +2,14 @@
 
 namespace DigitalPolygon\Polymer\Robo\Template;
 
-use Consolidation\Config\ConfigInterface;
 use DigitalPolygon\Polymer\Robo\Config\ConfigAwareTrait;
 use DigitalPolygon\Polymer\Robo\Discovery\Plugin\PluginBase;
-use League\Container\Container;
-use Robo\Contract\ConfigAwareInterface;
+use League\Container\ContainerAwareTrait;
 
-abstract class Template extends PluginBase implements TemplateInterface, ConfigAwareInterface
+abstract class Template extends PluginBase implements TemplateInterface
 {
     use ConfigAwareTrait;
-
-    public function __construct(ConfigInterface $config = null)
-    {
-        if ($config) {
-            $this->setConfig($config);
-        }
-    }
-
-    public static function create(Container $container): self
-    {
-        return new static($container->get('config'));
-    }
+    use ContainerAwareTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Robo/Template/TemplateInterface.php
+++ b/src/Robo/Template/TemplateInterface.php
@@ -2,7 +2,10 @@
 
 namespace DigitalPolygon\Polymer\Robo\Template;
 
-interface TemplateInterface
+use DigitalPolygon\Polymer\Robo\Discovery\Plugin\PluginInterface;
+use League\Container\Container;
+
+interface TemplateInterface extends PluginInterface
 {
     public const SERVICE_PREFIX = 'plugin.template.';
 

--- a/src/Robo/Template/TemplateInterface.php
+++ b/src/Robo/Template/TemplateInterface.php
@@ -6,8 +6,6 @@ use DigitalPolygon\Polymer\Robo\Discovery\Plugin\PluginInterface;
 
 interface TemplateInterface extends PluginInterface
 {
-    public const SERVICE_PREFIX = 'plugin.template.';
-
     /**
      * Unique ID of the template.
      *

--- a/src/Robo/Template/TemplateInterface.php
+++ b/src/Robo/Template/TemplateInterface.php
@@ -3,7 +3,6 @@
 namespace DigitalPolygon\Polymer\Robo\Template;
 
 use DigitalPolygon\Polymer\Robo\Discovery\Plugin\PluginInterface;
-use League\Container\Container;
 
 interface TemplateInterface extends PluginInterface
 {

--- a/src/Robo/Template/TemplatePluginManager.php
+++ b/src/Robo/Template/TemplatePluginManager.php
@@ -10,7 +10,6 @@ class TemplatePluginManager extends PluginManagerBase
     {
         $this->relativeNamespace = 'Polymer/Plugin/Template';
         $this->pluginInterface = TemplateInterface::class;
-        $this->pluginPrefix = 'template';
     }
 
     public function getCollections(): array

--- a/src/Robo/Template/TemplatePluginManager.php
+++ b/src/Robo/Template/TemplatePluginManager.php
@@ -19,8 +19,7 @@ class TemplatePluginManager extends PluginManagerBase
         /** @var TemplateInterface[] $templates */
         $templates = $this->getDefinitions();
         foreach ($templates as $plugin) {
-            $collections = $plugin->collections();
-            $collections = array_merge($collections, $collections);
+            $collections = array_merge($collections, $plugin->collections());
         }
         $collections = array_unique($collections);
         ksort($collections);

--- a/src/Robo/Template/TemplatePluginManager.php
+++ b/src/Robo/Template/TemplatePluginManager.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace DigitalPolygon\Polymer\Robo\Template;
+
+use DigitalPolygon\Polymer\Robo\Discovery\Plugin\PluginManagerBase;
+
+class TemplatePluginManager extends PluginManagerBase
+{
+    public function setDiscoveryData(): void
+    {
+        $this->relativeNamespace = 'Polymer/Plugin/Template';
+        $this->pluginInterface = TemplateInterface::class;
+        $this->pluginPrefix = 'template';
+    }
+
+    public function getCollections(): array
+    {
+        $collections = ['all'];
+        /** @var TemplateInterface[] $templates */
+        $templates = $this->getDefinitions();
+        foreach ($templates as $plugin) {
+            $collections = $plugin->collections();
+            $collections = array_merge($collections, $collections);
+        }
+        $collections = array_unique($collections);
+        ksort($collections);
+        return $collections;
+    }
+
+    public function hasCollection(string $collection): bool
+    {
+        $collections = $this->getCollections();
+        return in_array($collection, $collections);
+    }
+
+    public function getTemplatesFromCollection(string $collection): array
+    {
+        if (!$this->hasCollection($collection)) {
+            throw new \RuntimeException(sprintf("Template collection %s does not exist.", $collection));
+        }
+        /** @var TemplateInterface[] $templates */
+        $templates = $this->getDefinitions();
+        $templatesInCollection = [];
+        foreach ($templates as $template) {
+            if (in_array($collection, $template->collections())) {
+                $templatesInCollection[$template::id()] = $template;
+            }
+        }
+        ksort($templatesInCollection);
+        return $templatesInCollection;
+    }
+}


### PR DESCRIPTION
# Changes

- Introduces a plugin manager mechanism. This operates outside of the container. In the future each manager might get its own container with the core container as a delegate. Might be necessary if plugins need to use tasks. Also not in an ideal state because once the plugins are loaded, they share the same instance going forward, which might lead to unexpected behavior. Ideally each time a plugin is retrieved it is a fresh instance.
- Refactored Template plugin system to use plugin manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a centralized plugin management system for templates, allowing for streamlined retrieval, organization, and validation of template collections.
  - Established standardized interfaces to support dynamic dependency handling and robust plugin discovery, enhancing overall system extensibility.

- **Refactor**
  - Simplified the template structure by leveraging a more modular inheritance model, providing a cleaner and more consistent framework for future development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->