### PR TITLE
Discover contrib plugins via Composer metadata; custom from .polymer/plugins (PWT-115)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,6 @@
   },
   "require": {
     "php": ">=8.1",
-    "oomphinc/composer-installers-extender": "*",
-    "mnsami/composer-custom-directory-installer": "*",
     "composer-plugin-api": "^2.0",
     "composer-runtime-api": "^2.0",
     "consolidation/robo": "^4 || ^5",
@@ -32,8 +30,6 @@
     "sort-packages": true,
     "allow-plugins": {
       "composer/installers": true,
-      "mnsami/composer-custom-directory-installer": true,
-      "oomphinc/composer-installers-extender": true,
       "phpro/grumphp-shim": true,
       "phpstan/extension-installer": true
     }

--- a/src/Robo/Discovery/ExtensionDiscovery.php
+++ b/src/Robo/Discovery/ExtensionDiscovery.php
@@ -3,6 +3,7 @@
 namespace DigitalPolygon\Polymer\Core\Robo\Discovery;
 
 use Composer\Autoload\ClassLoader;
+use Composer\InstalledVersions;
 use DigitalPolygon\Polymer\Core\Robo\Extension\PolymerExtensionInterface;
 use Robo\ClassDiscovery\RelativeNamespaceDiscovery;
 use DigitalPolygon\Polymer\Core\Robo\Extension\ExtensionData;
@@ -94,30 +95,71 @@ class ExtensionDiscovery
 
     protected function findExtensions(): array
     {
-        $extensions = [];
-        $pluginDirectories = [
-            $this->polymerFilesRoot . '/plugins',
-        ];
+        // Contrib plugins are installed by Composer (type "polymer-plugin") and
+        // live wherever Composer puts them — vendor/ by default. Project-local
+        // custom plugins live under .polymer/plugins and take precedence by id.
+        return array_merge(
+            $this->findComposerInstalledExtensions(),
+            $this->findLocalExtensions()
+        );
+    }
 
-        // A plugin's .poly_info.yml marker lives at the plugin root, one or two
-        // levels below plugins/ (e.g. plugins/<name>/ or plugins/contrib/<name>/).
-        // Globbing at these fixed depths discovers plugins whether Composer
-        // installed them as symlinks (path repositories) or as real directories
-        // (dist/committed), while never descending into a plugin's own vendor/
-        // tree — which would otherwise surface vendored copies of other plugins.
-        $markerPatterns = [
-            '/*/*.poly_info.yml',
-            '/*/*/*.poly_info.yml',
-        ];
-        foreach ($pluginDirectories as $pluginDirectory) {
-            if (!is_dir($pluginDirectory)) {
+    /**
+     * Find contrib plugins installed by Composer, at whatever location.
+     *
+     * Uses the Composer runtime metadata to locate every package of type
+     * "polymer-plugin", so contrib plugins are discovered from the normal
+     * vendor install location without any installer-path configuration.
+     *
+     * @return array<string, string>
+     *   Extension id keyed to its installed directory.
+     */
+    protected function findComposerInstalledExtensions(): array
+    {
+        $extensions = [];
+        if (
+            !class_exists(InstalledVersions::class)
+            || !method_exists(InstalledVersions::class, 'getInstalledPackagesByType')
+        ) {
+            return $extensions;
+        }
+
+        foreach (InstalledVersions::getInstalledPackagesByType('polymer-plugin') as $package) {
+            $path = InstalledVersions::getInstallPath($package);
+            if ($path === null || !is_dir($path)) {
                 continue;
             }
-            foreach ($markerPatterns as $pattern) {
-                foreach (glob($pluginDirectory . $pattern) ?: [] as $markerFile) {
-                    $extensionName = str_replace('.poly_info.yml', '', basename($markerFile));
-                    $extensions[$extensionName] = dirname($markerFile);
-                }
+            foreach (glob($path . '/*.poly_info.yml') ?: [] as $markerFile) {
+                $extensionName = str_replace('.poly_info.yml', '', basename($markerFile));
+                $extensions[$extensionName] = dirname($markerFile);
+            }
+        }
+
+        return $extensions;
+    }
+
+    /**
+     * Find project-local custom plugins under .polymer/plugins.
+     *
+     * The .poly_info.yml marker lives at the plugin root, one or two levels
+     * below plugins/ (e.g. plugins/<name>/ or plugins/custom/<name>/). Globbing
+     * at these fixed depths avoids descending into any nested vendor/ tree.
+     *
+     * @return array<string, string>
+     *   Extension id keyed to its installed directory.
+     */
+    protected function findLocalExtensions(): array
+    {
+        $extensions = [];
+        $pluginDirectory = $this->polymerFilesRoot . '/plugins';
+        if (!is_dir($pluginDirectory)) {
+            return $extensions;
+        }
+
+        foreach (['/*/*.poly_info.yml', '/*/*/*.poly_info.yml'] as $pattern) {
+            foreach (glob($pluginDirectory . $pattern) ?: [] as $markerFile) {
+                $extensionName = str_replace('.poly_info.yml', '', basename($markerFile));
+                $extensions[$extensionName] = dirname($markerFile);
             }
         }
 

--- a/src/Robo/Discovery/ExtensionDiscovery.php
+++ b/src/Robo/Discovery/ExtensionDiscovery.php
@@ -98,10 +98,9 @@ class ExtensionDiscovery
         // Contrib plugins are installed by Composer (type "polymer-plugin") and
         // live wherever Composer puts them — vendor/ by default. Project-local
         // custom plugins live under .polymer/plugins and take precedence by id.
-        return array_merge(
-            $this->findComposerInstalledExtensions(),
-            $this->findLocalExtensions()
-        );
+        // The union operator keeps local entries on collision and preserves
+        // extension ids verbatim (array_merge would reindex numeric-looking ids).
+        return $this->findLocalExtensions() + $this->findComposerInstalledExtensions();
     }
 
     /**
@@ -120,6 +119,7 @@ class ExtensionDiscovery
         if (
             !class_exists(InstalledVersions::class)
             || !method_exists(InstalledVersions::class, 'getInstalledPackagesByType')
+            || !method_exists(InstalledVersions::class, 'getInstallPath')
         ) {
             return $extensions;
         }
@@ -130,7 +130,7 @@ class ExtensionDiscovery
                 continue;
             }
             foreach (glob($path . '/*.poly_info.yml') ?: [] as $markerFile) {
-                $extensionName = str_replace('.poly_info.yml', '', basename($markerFile));
+                $extensionName = basename($markerFile, '.poly_info.yml');
                 $extensions[$extensionName] = dirname($markerFile);
             }
         }
@@ -158,7 +158,7 @@ class ExtensionDiscovery
 
         foreach (['/*/*.poly_info.yml', '/*/*/*.poly_info.yml'] as $pattern) {
             foreach (glob($pluginDirectory . $pattern) ?: [] as $markerFile) {
-                $extensionName = str_replace('.poly_info.yml', '', basename($markerFile));
+                $extensionName = basename($markerFile, '.poly_info.yml');
                 $extensions[$extensionName] = dirname($markerFile);
             }
         }


### PR DESCRIPTION
## Summary

Makes plugin discovery independent of where plugins are installed, so contrib plugins can live in the normal `vendor/` location and project-local custom plugins live under `.polymer/plugins` — no per-project installer-path configuration required.

Refs PWT-115.

## What changed

`ExtensionDiscovery::findExtensions()` now merges two sources:

- **Contrib plugins** — located via `Composer\InstalledVersions::getInstalledPackagesByType('polymer-plugin')` + `getInstallPath()`, then reading each package's `*.poly_info.yml`. They're discovered wherever Composer installs them (`vendor/` by default), so no `installer-paths`/extender machinery is needed.
- **Custom plugins** — the existing fixed-depth glob scan of `<repo>/.polymer/plugins` for project-local, committed plugins.

Local (custom) entries take precedence by extension id. Guarded when the Composer runtime API (`getInstalledPackagesByType`) is unavailable.

## Context

PWT-115 originally aimed at *remappable installer paths*. While implementing, two heavier approaches were explored and rejected after verification:
- Auto-injecting installer-paths from the Composer plugin's `activate()` — **doesn't work** (composer/installers-extender reads `installer-types` at its own activation; plugin ordering means the injection is too late and the package falls back to `vendor/`).
- A configurable `extension_paths` discovery key — dropped, since managing install locations turned out not to be desired.

The accepted design above is simpler and removes the need to manage install locations at all.

## Testing

- PHPUnit: 14/14; PHPStan (level 6) and phpcs clean.
- End-to-end in the consuming project: with the polymer `installer-paths` removed from the project `composer.json`, `composer install` places contrib plugins in `vendor/digitalpolygon/*`, and `polymer plugin:list` discovers them from there; all extension commands register; `plugin:enable`/`disable` gating still works (0 ↔ 7 commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
