### PR TITLE
Don't abort composer install when polymer:init can't run

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -192,9 +192,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * Executes `polymer polymer:update` and `polymer-console polymer:update` commands.
-     *
-     * @throws \Exception
+     * Scaffolds Polymer's project template files on initial install.
      */
     protected function executePolymerUpdate(): void
     {
@@ -204,8 +202,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $command = $this->getVendorPath() . '/bin/polymer polymer:init';
             $success = $this->executeCommand($command, [], true);
             if (!$success) {
-                $this->io->writeError("<error>Polymer installation failed! Please execute <comment>$command --verbose</comment> to debug the issue.</error>");
-                throw new \Exception('Installation aborted due to error');
+                // Scaffolding is a convenience for projects adopting Polymer. When
+                // Polymer is pulled in as a transitive dependency (e.g. an extension
+                // package's own CI) there is no project to initialize, so warn and
+                // continue rather than aborting the entire composer install.
+                $this->io->writeError("<warning>Polymer could not initialize project files; skipping. If this is a Polymer project, run <comment>$command --verbose</comment> to debug.</warning>");
             }
         }
     }

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -197,15 +197,19 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     protected function executePolymerUpdate(): void
     {
         if ($this->isInitialInstall()) {
+            // Only initialize within an actual Polymer project, which has a
+            // .polymer directory at its root. When Polymer is pulled in as a
+            // transitive dependency (e.g. an extension package's own CI) there is
+            // nothing to initialize, so skip silently rather than emitting noise
+            // or aborting the composer install.
+            if (!is_dir($this->getRepoRoot() . '/.polymer')) {
+                return;
+            }
             $this->io->write('<info>Creating Polymer template files...</info>');
             /** @var string $command */
             $command = $this->getVendorPath() . '/bin/polymer polymer:init';
             $success = $this->executeCommand($command, [], true);
             if (!$success) {
-                // Scaffolding is a convenience for projects adopting Polymer. When
-                // Polymer is pulled in as a transitive dependency (e.g. an extension
-                // package's own CI) there is no project to initialize, so warn and
-                // continue rather than aborting the entire composer install.
                 $this->io->writeError("<warning>Polymer could not initialize project files; skipping. If this is a Polymer project, run <comment>$command --verbose</comment> to debug.</warning>");
             }
         }


### PR DESCRIPTION
## Summary

The Composer plugin scaffolds project files on initial install by running `vendor/bin/polymer polymer:init`. When Polymer is pulled in as a **transitive dependency** — e.g. an extension package like `polymer-drupal` / `polymer-pantheon-drupal` building in CI — there is no Polymer project to initialize, so `bin/polymer` exits with *"Could not find .polymer directory"*. The plugin rethrew that as a fatal `Installation aborted due to error`, breaking `composer install` outright (this is currently red on digitalpolygon/polymer-drupal#28 and polymer-pantheon-drupal#35).

Scaffolding is a convenience, not a precondition for installing the library, so the plugin now logs a warning and continues instead of aborting the whole install.

## Why this surfaced now
With contrib/core moving to the normal `vendor/` location (PWT-115), installing Polymer no longer auto-creates a `.polymer/` directory, so the post-install `polymer:init` reliably fails in non-project contexts — which then aborted dependency installs.

## Testing
- PHPStan (level 6) and phpcs clean.
- Will be confirmed green by the dependent extension PRs' CI once this lands on `0.x` and they re-resolve `digitalpolygon/polymer:0.x-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
